### PR TITLE
Added field exclusion, conforming to MongoDb's field selection abilities

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -291,7 +291,7 @@ class Builder
     {
         $select = func_get_args();
         foreach ($select as $fieldName) {
-            $this->query['select'][$fieldName] = true;
+            $this->query['select'][$fieldName] = 1;
         }
         return $this;
     }
@@ -306,7 +306,7 @@ class Builder
     {
         $select = func_get_args();
         foreach ($select as $fieldName) {
-            $this->query['select'][$fieldName] = false;
+            $this->query['select'][$fieldName] = 0;
         }
         return $this;
     }


### PR DESCRIPTION
As described in MongoDb's documentation, you can [retrieve a subset of fields by inclusion or exclusion](http://www.mongodb.org/display/DOCS/Retrieving+a+Subset+of+Fields).

Changes done to conform to MongoDB field selection :
- new function Builder::exclude($fields)  
- update of Builder::select() in order to have an hash instead of an array of selected fields (selectSlice() is  already using an hash !)

Currently, mixing includes and excludes is not supported in MongoDb but [it seems to be planned for 1.9](http://jira.mongodb.org/browse/SERVER-391). If you try to do so an explicit error is raised, no need to implement an error control.
