### PR TITLE
Ensure index

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -426,7 +426,7 @@ class Collection
     }
 
     /** @proxy */
-    public function ensureIndex(array $keys, array $options)
+    public function ensureIndex(array $keys, array $options = array())
     {
         return $this->mongoCollection->ensureIndex($keys, $options);
     }


### PR DESCRIPTION
Just a minor tweak to have 2nd param optional on ensureIndex() like it is with php MongoCollection:ensureIndex()
