### PR TITLE
Fixed missing EventArgs namespace use statement, added Test to ensure event dispatching works

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,7 +89,7 @@ available events are:
 You can connect to these events using the EventManager:
 
     use Doctrine\MongoDB\Events;
-    use Doctrine\MongoDB\Events\EventArgs;
+    use Doctrine\MongoDB\Event\EventArgs;
 
     $connectionEvents = new ConnectionEvents();
     $evm->addEventListener(Events::preConnect, $connectionEvents);

--- a/lib/Doctrine/MongoDB/Connection.php
+++ b/lib/Doctrine/MongoDB/Connection.php
@@ -19,7 +19,8 @@
 
 namespace Doctrine\MongoDB;
 
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventManager,
+    Doctrine\MongoDB\Event\EventArgs;
 
 /**
  * Wrapper for the PHP Mongo class.

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -19,7 +19,8 @@
 
 namespace Doctrine\MongoDB;
 
-use Doctrine\Common\EventManager;
+use Doctrine\Common\EventManager,
+    Doctrine\MongoDB\Event\EventArgs;
 
 /**
  * Wrapper for the PHP MongoDB class.

--- a/tests/Doctrine/MongoDB/Tests/EventTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests;
+
+use Doctrine\MongoDB\Connection;
+use Doctrine\Common\EventManager;
+use PHPUnit_Framework_TestCase;
+use Mongo;
+
+class EventTest extends PHPUnit_Framework_TestCase
+{
+    public function testEventArgsNamespaceTest() 
+    {
+        $listener = new ListenerStub();
+        $manager  = new EventManager();
+
+        $manager->addEventListener(\Doctrine\MongoDB\Events::preConnect, $listener);
+
+        $connection = new Connection(null, array(), null, $manager);
+        $connection->initialize();
+    }
+}
+
+class ListenerStub {
+    function preConnect() {}
+}


### PR DESCRIPTION
In Doctrine\MongoDB\Connection and Doctrine\MongoDB\Database the EventArgs namespace were wrong. The namespace is Doctrine\MongoDB\Event\EventArgs, trough the missing declaration the autoloader/PHP assumend it was Doctrine\MongoDB\EventArgs. I added a use statement to both files to fix this problem and also created a test that shows the error on a non-patched checkout.

sven@sven-thinkpad:~/Workspace/Projects/doctrine-mongodb$ phpunit
PHPUnit 3.5.13 by Sebastian Bergmann.

...................PHP Fatal error:  Doctrine\Common\ClassLoader::loadClass(): Failed opening required '/var/www/projects/doctrine-mongodb/tests/../lib/Doctrine/MongoDB/EventArgs.php' (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/projects/doctrine-mongodb/lib/vendor/doctrine-common/lib/Doctrine/Common/ClassLoader.php on line 148
