### PR TITLE
Map/Reduce: set the default value for inline to `true` instead of `1`

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -620,7 +620,7 @@ class Builder
      * @param array $options
      * @return Query
      */
-    public function mapReduce($map, $reduce, array $out = array('inline' => 1), array $options = array())
+    public function mapReduce($map, $reduce, array $out = array('inline' => true), array $options = array())
     {
         $this->query['type'] = Query::TYPE_MAP_REDUCE;
         $this->query['mapReduce'] = array(


### PR DESCRIPTION
See Doctrine/MongoDB/Collection.php line 371

```
if (isset($out['inline']) && $out['inline'] === true) {
```

So we need `true`, not `1`

This commit fixes the test `MapReduceTest` of mongodb-odm.
