### PR TITLE
Added Mongo version check

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -143,6 +143,10 @@ class Collection
 
     protected function doBatchInsert(array &$a, array $options = array())
     {
+        if (version_compare(\Mongo::VERSION, '1.0.5', '<')){
+            return $this->mongoCollection->batchInsert($a);
+        }
+
         return $this->mongoCollection->batchInsert($a, $options);
     }
 


### PR DESCRIPTION
According to the doc for MongoCollection::batchInsert() http://www.php.net/manual/en/mongocollection.batchinsert.php
The $options parameter was added in version 1.0.5.  Since there was no check in play PHP would issue a warning on Mongo < 1.0.5.  I added the check to make sure that the $options param is passed only with mongo > 1.0.5
