### PR TITLE
Adding experimental retry functionality.

### DIFF
--- a/lib/Doctrine/MongoDB/Configuration.php
+++ b/lib/Doctrine/MongoDB/Configuration.php
@@ -34,7 +34,11 @@ class Configuration
      *
      * @var array $attributes
      */
-    protected $attributes = array('mongoCmd' => '$');
+    protected $attributes = array(
+        'mongoCmd' => '$',
+        'retryConnect' => 3,
+        'retryQuery' => 3
+    );
 
     /**
      * Set the logger callable.
@@ -73,5 +77,45 @@ class Configuration
     public function setMongoCmd($cmd)
     {
         $this->attributes['mongoCmd'] = $cmd;
+    }
+
+    /**
+     * Get number of times to retry connect when errors occur.
+     *
+     * @return mixed True/False or number of times to retry.
+     */
+    public function getRetryConnect()
+    {
+        return $this->attributes['retryConnect'];
+    }
+
+    /**
+     * Set number of times to retry connect when errors occur.
+     *
+     * @param string $retryConnect 
+     */
+    public function setRetryConnect($retryConnect)
+    {
+        $this->attributes['retryConnect'] = $retryConnect;
+    }
+
+    /**
+     * Get number of times to retry queries when
+     *
+     * @return mixed True/False or number of times to retry queries.
+     */
+    public function getRetryQuery()
+    {
+        return $this->attributes['retryQuery'];
+    }
+
+    /**
+     * Set true/false whether or not to retry connect upon failure or number of times to retry.
+     *
+     * @param mixed $retryQuery True/false or number of times to retry queries.
+     */
+    public function setRetryQuery($retryQuery)
+    {
+        $this->attributes['retryQuery'] = $retryQuery;
     }
 }

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -51,17 +51,26 @@ class Database
     protected $cmd;
 
     /**
+     * Number of times to retry queries.
+     *
+     * @var mixed
+     */
+    protected $numRetries;
+
+    /**
      * Create a new MongoDB instance which wraps a PHP MongoDB instance.
      *
      * @param MongoDB $mongoDB  The MongoDB instance to wrap.
      * @param EventManager $evm  The EventManager instance.
      * @param string $cmd  The MongoDB cmd character.
+     * @param mixed $numRetries Number of times to retry queries.
      */
-    public function __construct(\MongoDB $mongoDB, EventManager $evm, $cmd)
+    public function __construct(\MongoDB $mongoDB, EventManager $evm, $cmd, $numRetries)
     {
         $this->mongoDB = $mongoDB;
         $this->eventManager = $evm;
         $this->cmd = $cmd;
+        $this->numRetries = $numRetries;
     }
 
     /**
@@ -250,7 +259,7 @@ class Database
     protected function wrapCollection(\MongoCollection $collection)
     {
         return new Collection(
-            $collection, $this, $this->eventManager, $this->cmd
+            $collection, $this, $this->eventManager, $this->cmd, $this->numRetries
         );
     }
 

--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -45,14 +45,15 @@ class LoggableDatabase extends Database implements Loggable
      * @param MongoDB $mongoDB  The MongoDB instance to wrap.
      * @param EventManager $evm  The EventManager instance.
      * @param string $cmd  The MongoDB cmd character.
+     * @param mixed $numRetries Number of times to retry queries.
      * @param Closure $loggerCallable  Logger callback function.
      */
-    public function __construct(\MongoDB $mongoDB, EventManager $evm, $cmd, $loggerCallable)
+    public function __construct(\MongoDB $mongoDB, EventManager $evm, $cmd, $numRetries, $loggerCallable)
     {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
-        parent::__construct($mongoDB, $evm, $cmd);
+        parent::__construct($mongoDB, $evm, $cmd, $numRetries);
         $this->loggerCallable = $loggerCallable;
     }
 


### PR DESCRIPTION
In our application at OpenSky we're dealing with errors from mongodb connections and cursors when our replica set changes. For example when a master steps down, it may take a few seconds for a slave to be elected as primary so during that time we need to handle this and retry functions that can throw MongoConnectionException and MongoCursorException.

Sometimes randomly we've gotten the errors as well so I think we just need to handle it and retry when it happens. For example when iterating over a cursor, you may get an exception from one getNext() call but simply trying again right afterwards it will work.
