### PR TITLE
Add functionality that allows eagerCursor(true) on query builders

### DIFF
--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -1,0 +1,112 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the LGPL. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB;
+
+/**
+ * EagerCursor class.
+ *
+ * @license     http://www.opensource.org/licenses/lgpl-license.php LGPL
+ * @link        www.doctrine-project.org
+ * @since       1.0
+ * @author      Jonathan H. Wage <jonwage@gmail.com>
+ */
+class EagerCursor implements Iterator
+{
+    /** @var object Doctrine\MongoDB\Cursor */
+    protected $cursor;
+
+    /** @var array Array of data from Cursor to iterate over */
+    protected $data = array();
+
+    /** @var bool Whether or not the EagerCursor has been initialized */
+    protected $initialized = false;
+
+    public function __construct(Cursor $cursor)
+    {
+        $this->cursor = $cursor;
+    }
+
+    public function getCursor()
+    {
+        return $this->cursor;
+    }
+
+    public function isInitialized()
+    {
+        return $this->initialized;
+    }
+
+    public function initialize()
+    {
+        if ($this->initialized === false) {
+            $this->data = $this->cursor->toArray();
+        }
+        $this->initialized = true;
+    }
+
+    public function rewind()
+    {
+        $this->initialize();
+        reset($this->data);
+    }
+  
+    public function current()
+    {
+        $this->initialize();
+        return current($this->data);
+    }
+  
+    public function key() 
+    {
+        $this->initialize();
+        return key($this->data);
+    }
+  
+    public function next() 
+    {
+        $this->initialize();
+        return next($this->data);
+    }
+  
+    public function valid()
+    {
+        $this->initialize();
+        $key = key($this->data);
+        return ($key !== NULL && $key !== FALSE);
+    }
+
+    public function count()
+    {
+        $this->initialize();
+        return count($this->data);
+    }
+
+    public function toArray()
+    {
+        $this->initialize();
+        return $this->data;
+    }
+
+    public function getSingleResult()
+    {
+        $this->initialize();
+        return $this->current();
+    }
+}

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -70,6 +70,7 @@ class Builder
         'immortal' => false,
         'snapshot' => false,
         'slaveOkay' => false,
+        'eagerCursor' => false,
         'mapReduce' => array(
             'map' => null,
             'reduce' => null,
@@ -130,6 +131,18 @@ class Builder
     public function slaveOkay($bool = true)
     {
         $this->query['slaveOkay'] = $bool;
+        return $this;
+    }
+
+    /**
+     * Set eager cursor.
+     *
+     * @param bool $bool
+     * @return Builder
+     */
+    public function eagerCursor($bool = true)
+    {
+        $this->query['eagerCursor'] = $bool;
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -19,11 +19,12 @@
 
 namespace Doctrine\MongoDB\Query;
 
-use Doctrine\MongoDB\IteratorAggregate;
-use Doctrine\MongoDB\Iterator;
-use Doctrine\MongoDB\Database;
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Cursor;
+use Doctrine\MongoDB\Database;
+use Doctrine\MongoDB\EagerCursor;
+use Doctrine\MongoDB\IteratorAggregate;
+use Doctrine\MongoDB\Iterator;
 
 /**
  * Query is responsible for executing and returning the results from queries built by the
@@ -142,8 +143,7 @@ class Query implements IteratorAggregate
                     $this->query['query'][$this->cmd . 'where'] = $this->query['mapReduce']['reduce'];
                 }
                 $cursor = $this->collection->find($this->query['query'], $this->query['select']);
-                $this->prepareCursor($cursor);
-                return $cursor;
+                return $this->prepareCursor($cursor);
 
             case self::TYPE_FIND_AND_UPDATE:
                 if ($this->query['sort']) {
@@ -193,7 +193,7 @@ class Query implements IteratorAggregate
                 $cursor = $this->collection->mapReduce($this->query['mapReduce']['map'], $this->query['mapReduce']['reduce'], $this->query['mapReduce']['out'], $this->query['query'], $options);
 
                 if ($cursor instanceof Cursor) {
-                    $this->prepareCursor($cursor);
+                    $cursor = $this->prepareCursor($cursor);
                 }
 
                 return $cursor;
@@ -225,6 +225,10 @@ class Query implements IteratorAggregate
         foreach ($this->query['hints'] as $keyPattern) {
             $cursor->hint($keyPattern);
         }
+        if ($this->query['eagerCursor'] === true) {
+            $cursor = new EagerCursor($cursor);
+        }
+        return $cursor;
     }
 
     /**

--- a/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests;
+
+use Doctrine\MongoDB\Configuration;
+use Doctrine\MongoDB\Connection;
+use Doctrine\MongoDB\GridFSFile;
+
+class EagerCursorTest extends BaseTest
+{
+    private $document;
+    private $test;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->document = array('test' => 'test');
+        $this->conn->selectCollection('db', 'users')->insert($this->document);
+
+        $qb = $this->conn->selectCollection('db', 'users')->createQueryBuilder();
+        $qb->eagerCursor(true);
+        $this->test = $qb->getQuery()->execute();
+    }
+
+    public function testEagerCursor()
+    {
+        $this->assertInstanceOf('Doctrine\MongoDB\EagerCursor', $this->test);
+    }
+
+    public function testIsInitialized()
+    {
+        $this->assertFalse($this->test->isInitialized());
+        $this->test->initialize();
+        $this->assertTrue($this->test->isInitialized());
+    }
+
+    public function testCount()
+    {
+        $this->assertEquals(1, count($this->test));
+    }
+
+    public function testGetSingleResult()
+    {
+        $this->assertEquals($this->document, $this->test->getSingleResult());
+    }
+
+    public function testToArray()
+    {
+        $this->assertEquals(array((string) $this->document['_id'] => $this->document), $this->test->toArray());
+    }
+
+    public function testRewind()
+    {
+        $this->test->toArray();
+        $this->assertFalse($this->test->next());
+        $this->test->rewind();
+        $this->assertEquals($this->document, $this->test->current());
+        $this->assertFalse($this->test->next());
+    }
+}


### PR DESCRIPTION
When used it will return a different type of cursor that eagerly fetches all documents when you start iteration instead of one document per iteration. So it loads all data in to memory before starting iteration.

Without eager cursor:

```
$qb = $this->conn->selectCollection('dbname', 'collection')->createQueryBuilder();
$cursor = $qb->getQuery()->execute();
foreach ($cursor as $document) { // only loads one $document at a time
}
```

With eager cursor:

```
$qb = $this->conn->selectCollection('dbname', 'collection')->createQueryBuilder();
$qb->eagerCursor(true);
$cursor = $qb->getQuery()->execute();
foreach ($cursor as $document) { // loads all documents in to memory before iterating
}
```

This will tie in to #40 where we have retry functionality. In order to benefit from retries on cursors, you will have to use an eager cursor so that the data fetching is all done before iteration starts so that if a cursor error happens you can try again with a new cursor.
