### PR TITLE
Use one database for all functional tests and only drop collections from that database on teardown

### DIFF
--- a/tests/Doctrine/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/BaseTest.php
@@ -8,26 +8,25 @@ use Doctrine\MongoDB\Connection;
 
 abstract class BaseTest extends PHPUnit_Framework_TestCase
 {
+    protected static $dbName = 'doctrine_mongodb';
+
     protected $conn;
 
     public function setUp()
     {
         $config = new Configuration();
-        $config->setLoggerCallable(function($msg) {
-            //print_r($msg);
-        });
+        $config->setLoggerCallable(function($msg) {});
         $this->conn = new Connection(null, array(), $config);
     }
 
     public function tearDown()
     {
-        $dbs = $this->conn->listDatabases();
-        foreach ($dbs['databases'] as $db) {
-            $collections = $this->conn->selectDatabase($db['name'])->listCollections();
-            foreach ($collections as $collection) {
-                $collection->drop();
-            }
+        $collections = $this->conn->selectDatabase(self::$dbName)->listCollections();
+        foreach ($collections as $collection) {
+            $collection->drop();
         }
+
         $this->conn->close();
+        unset($this->conn);
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/CursorFunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorFunctionalTest.php
@@ -6,7 +6,7 @@ class CursorFunctionalTest extends BaseTest
 {
     public function testRecreate()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $coll = $db->selectCollection('users');
 
         $doc1 = array('test' => 'test');
@@ -28,7 +28,7 @@ class CursorFunctionalTest extends BaseTest
 
     public function testGetSingleResult()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $coll = $db->selectCollection('users');
 
         $doc1 = array('test' => 'test', 'doc' => 1);

--- a/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
@@ -15,9 +15,9 @@ class EagerCursorTest extends BaseTest
     {
         parent::setUp();
         $this->document = array('test' => 'test');
-        $this->conn->selectCollection('db', 'users')->insert($this->document);
+        $this->conn->selectCollection(self::$dbName, 'users')->insert($this->document);
 
-        $qb = $this->conn->selectCollection('db', 'users')->createQueryBuilder();
+        $qb = $this->conn->selectCollection(self::$dbName, 'users')->createQueryBuilder();
         $qb->eagerCursor(true);
         $this->test = $qb->getQuery()->execute();
     }

--- a/tests/Doctrine/MongoDB/Tests/FunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/FunctionalTest.php
@@ -8,7 +8,7 @@ class FunctionalTest extends BaseTest
 {
     public function testUpsertSetsId()
     {
-        $db = $this->conn->selectDatabase('test');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $coll = $db->createCollection('test');
         $criteria = array();
         $newObj = array('$set' => array('test' => 'test'));
@@ -44,7 +44,7 @@ class FunctionalTest extends BaseTest
             ),
         );
 
-        $db = $this->conn->selectDatabase('test');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $coll = $db->createCollection('test');
         $coll->batchInsert($data);
 
@@ -65,7 +65,7 @@ class FunctionalTest extends BaseTest
 
         $finalize = 'function (key, value) { value.test = "test"; return value; }';
 
-        $db = $this->conn->selectDatabase('test');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $coll = $db->selectCollection('test');
         $qb = $coll->createQueryBuilder()
             ->map($map)->reduce($reduce)->finalize($finalize);
@@ -78,7 +78,7 @@ class FunctionalTest extends BaseTest
 
     public function testIsFieldIndexed()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
 
         $coll = $db->selectCollection('users');
         $this->assertFalse($coll->isFieldIndexed('test'));
@@ -88,7 +88,7 @@ class FunctionalTest extends BaseTest
 
     public function testFunctional()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
 
         $coll = $db->selectCollection('users');
 
@@ -103,7 +103,7 @@ class FunctionalTest extends BaseTest
 
     public function testFunctionalGridFS()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $files = $db->getGridFS('files');
         $file = array(
             'title' => 'test file',

--- a/tests/Doctrine/MongoDB/Tests/GridFSFileTest.php
+++ b/tests/Doctrine/MongoDB/Tests/GridFSFileTest.php
@@ -88,7 +88,7 @@ class GridFSFileTest extends BaseTest
 
     public function testFunctional()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
 
         $path = __DIR__.'/file.txt';
         $gridFS = $db->getGridFS();
@@ -117,7 +117,7 @@ class GridFSFileTest extends BaseTest
 
     public function testStoreFile()
     {
-        $db = $this->conn->selectDatabase('doctrine_mongodb');
+        $db = $this->conn->selectDatabase(self::$dbName);
         $gridFS = $db->getGridFS();
 
         $metadata = array(


### PR DESCRIPTION
Went to work on something else and it wiped out my local dbs. 
