### PR TITLE
Add use_keys parameter to Cursor::toArray()

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -317,11 +317,11 @@ class Cursor implements Iterator
         return $this->mongoCursor->valid();
     }
 
-    public function toArray()
+    public function toArray($useKeys = true)
     {
         $cursor = $this;
         return $this->retry(function() use ($cursor) {
-            return iterator_to_array($cursor);
+            return iterator_to_array($cursor, $useKeys);
         }, true);
     }
 


### PR DESCRIPTION
The use case is I want to serialize a Document with numeric index, but the current implementation will serialize it to associative array with Id as the key.
