### PR TITLE
Remove ambiguity

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -590,7 +590,7 @@ class Builder
 
 
     /**
-     * Set sort and erase all old sorts.
+     * Set sort.
      *
      * @param string $fieldName
      * @param string $order


### PR DESCRIPTION
Hello everybody!

I propose to remove ambiguity. "Erase all old sorts" implies that each subsequent sort() call removes effects of a previous sort() calls, which is not true.

I guess, it was meant to say "erase all old sorts on this field", but instead it reads as a global statement.
