### PR TITLE
Doctrine\MongoDB\LoggableDatabase::command() should be compatible with Doctrine\MongoDB\Database::command(array $data, array $options = Array)

### DIFF
--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -80,14 +80,15 @@ class LoggableDatabase extends Database implements Loggable
         return parent::authenticate($username, $password);
     }
 
-    public function command(array $data)
+    public function command(array $data, array $options = array())
     {
         $this->log(array(
             'command' => true,
-            'data' => $data
+            'data' => $data,
+            'options' => $options
         ));
 
-        return parent::command($data);
+        return parent::command($data, $options);
     }
 
     public function createCollection($name, $capped = false, $size = 0, $max = 0)


### PR DESCRIPTION
This PR fixes a notice:

  Runtime Notice: Declaration of Doctrine\MongoDB\LoggableDatabase::command() should be compatible with Doctrine\MongoDB\Database::command(array $data, array $options = Array) in lib/Doctrine/MongoDB/LoggableDatabase.php line 33
