### PR TITLE
Add check in doUpdate() to make sure the document containing the file is returned

### DIFF
--- a/lib/Doctrine/MongoDB/GridFS.php
+++ b/lib/Doctrine/MongoDB/GridFS.php
@@ -70,7 +70,10 @@ class GridFS extends Collection
 
             // First do a find and remove query to remove the file metadata and chunks so
             // we can restore the file below
-            $document = $this->findAndRemove($query, $options);
+            if (null === $document = $this->findAndRemove($query, $options)) {
+                throw new \Exception("Could not find original document containing file");
+            }
+            
             unset(
                 $document['filename'],
                 $document['length'],


### PR DESCRIPTION
Added check in doUpdate() to make sure the document containing the file is returned when updating an existing document with a new file.

I had this rare issue when connecting to a replicaSet. Issue appears to be fixed in PHP mongo driver already but a check here would not hurt.
