### PR TITLE
Added support for geonear spherical option

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -598,6 +598,18 @@ class Builder
     }
 
     /**
+     * Set the "spherical" option for a geoNear command query.
+     *
+     * @param bool $spherical
+     * @return Builder
+     */
+    public function spherical($spherical)
+    {
+        $this->query['geoNear']['spherical'] = $spherical;
+        return $this;
+    }
+
+    /**
      * Add where $near query.
      *
      * @param string $x

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -217,7 +217,7 @@ class Query implements IteratorAggregate
                     $this->options['num'] = $this->query['limit'];
                 }
 
-                foreach (array('distanceMultiplier', 'maxDistance') as $key) {
+                foreach (array('distanceMultiplier', 'maxDistance', 'spherical') as $key) {
                     if (isset($this->query['geoNear'][$key]) && $this->query['geoNear'][$key]) {
                         $this->options[$key] = $this->query['geoNear'][$key];
                     }

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -433,6 +433,7 @@ class BuilderTest extends BaseTest
             ->geoNear(50, 50)
             ->distanceMultiplier(2.5)
             ->maxDistance(5)
+            ->spherical(true)
             ->field('type')->equals('restaurant')
             ->limit(10);
 
@@ -445,6 +446,7 @@ class BuilderTest extends BaseTest
         $this->assertEquals(array(50, 50), $geoNear['near']);
         $this->assertEquals(2.5, $geoNear['distanceMultiplier']);
         $this->assertEquals(5, $geoNear['maxDistance']);
+        $this->assertEquals(true, $geoNear['spherical']);
         $this->assertEquals(10, $qb->debug('limit'));
         $this->assertInstanceOf('Doctrine\MongoDB\ArrayIterator', $qb->getQuery()->execute());
     }

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -50,6 +50,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
                 'near' => array(50, 50),
                 'distanceMultiplier' => 2.5,
                 'maxDistance' => 5,
+                'spherical' => true,
             ),
             'limit' => 10,
             'query' => array('altitude' => array('$gt' => 1)),
@@ -70,6 +71,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
                           $this->logicalAnd(
                               new ArrayHasValueUnderKey('distanceMultiplier', 2.5),
                               new ArrayHasValueUnderKey('maxDistance', 5),
+                              new ArrayHasValueUnderKey('spherical', true),
                               new ArrayHasValueUnderKey('num', 10)
                           )
                    );


### PR DESCRIPTION
I just added the support of the spherical (true or false) option in a geoNear search.

I also updated the test files in case but didn't run them. (I'm a beginner, and had this error : install dependencies to run test suite).
