### PR TITLE
Cursor should be reset and limit should be restored after calling getSingleResult

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -334,8 +334,10 @@ class Cursor implements Iterator
     {
         $originalLimit = $this->limit;
         $this->limit(1);
-        $results = $this->toArray();
-        return $results ? current($results) : null;
+        $result = current($this->toArray()) ?: null;
+        $this->reset();
+        $this->limit($originalLimit);
+        return $result;
     }
 
     protected function retry(\Closure $retry, $recreate = false)

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests;
+
+class CursorTest extends BaseTest
+{
+    private $doc1;
+    private $doc2;
+    private $doc3;
+
+    private $cursor;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->doc1 = array('name' => 'A');
+        $this->doc2 = array('name' => 'B');
+        $this->doc3 = array('name' => 'C');
+
+        $collection = $this->conn->selectCollection(self::$dbName, 'docs');
+        $collection->insert($this->doc1);
+        $collection->insert($this->doc2);
+        $collection->insert($this->doc3);
+
+        $this->cursor = $collection->createQueryBuilder()->getQuery()->execute();
+        $this->cursor->sort(array('name' => 1));
+    }
+
+    /**
+     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     */
+    public function testGetSingleResult()
+    {
+        $this->assertEquals($this->doc1, $this->cursor->getSingleResult());
+    }
+
+    /**
+     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     */
+    public function testCursorIsResetAfterGetSingleResult()
+    {
+        $this->assertEquals($this->doc1, $this->cursor->getSingleResult());
+
+        // Make sure limit is restored and cursor is rewound
+        $expected = array($this->doc1, $this->doc2, $this->doc3);
+        $actual = array();
+        foreach ($this->cursor as $entry) {
+            $actual[] = $entry;
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     */
+    public function testGetSingleResultReturnsNull()
+    {
+        $collection = $this->conn->selectCollection(self::$dbName, 'tmp');
+        $collection->remove(array());
+        $cursor = $collection->createQueryBuilder()->getQuery()->execute();
+        $this->assertNull($cursor->getSingleResult());
+    }
+}


### PR DESCRIPTION
Currently calling getSingleResult leaves cursor in a weird state.
I think the following scenario makes sense

``` php
<?php

$document = $cursor->getSingleResult();
echo 'Newest document in this collection was created: ' . date('c', $document['created_at']->sec);

foreach ($cursor as $document) {
    // do something with a document
}
```

Currently if I try iterating over a cursor after calling getSingleResult I'm only going to get the second document in that cursor.
