### PR TITLE
complete retry support for Loggable* wrappers

### DIFF
--- a/lib/Doctrine/MongoDB/LoggableCollection.php
+++ b/lib/Doctrine/MongoDB/LoggableCollection.php
@@ -51,14 +51,15 @@ class LoggableCollection extends Collection implements Loggable
      * @param EventManager $evm The EventManager instance.
      * @param string $cmd Mongo cmd character.
      * @param Closure $loggerCallable The logger callable.
+     * @param boolean|integer $numRetries Number of times to retry queries.
      */
-    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $cmd, $loggerCallable)
+    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $cmd, $loggerCallable, $numRetries = 0)
     {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
         $this->loggerCallable = $loggerCallable;
-        parent::__construct($connection, $name, $database, $evm, $cmd);
+        parent::__construct($connection, $name, $database, $evm, $cmd, $numRetries);
     }
 
     /**
@@ -253,6 +254,6 @@ class LoggableCollection extends Collection implements Loggable
     /** @override */
     protected function wrapCursor(\MongoCursor $cursor, $query, $fields)
     {
-        return new LoggableCursor($this->connection, $this, $cursor, $this->loggerCallable, $query, $fields);
+        return new LoggableCursor($this->connection, $this, $cursor, $this->loggerCallable, $query, $fields, $this->numRetries);
     }
 }

--- a/lib/Doctrine/MongoDB/LoggableCursor.php
+++ b/lib/Doctrine/MongoDB/LoggableCursor.php
@@ -59,13 +59,14 @@ class LoggableCursor extends Cursor implements Loggable
      * @param mixed $loggerCallable Logger callable.
      * @param array $query The query array that was used to create this cursor.
      * @param array $query The fields selected on this cursor.
+     * @param boolean|integer $numRetries Number of times to retry queries.
      */
-    public function __construct(Connection $connection, Collection $collection, \MongoCursor $mongoCursor, $loggerCallable, array $query, array $fields)
+    public function __construct(Connection $connection, Collection $collection, \MongoCursor $mongoCursor, $loggerCallable, array $query, array $fields, $numRetries = 0)
     {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
-        parent::__construct($connection, $collection, $mongoCursor);
+        parent::__construct($connection, $collection, $mongoCursor, $query, $fields, $numRetries);
         $this->loggerCallable = $loggerCallable;
         $this->query = $query;
         $this->fields = $fields;

--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -153,7 +153,7 @@ class LoggableDatabase extends Database implements Loggable
     protected function doSelectCollection($name)
     {
         return new LoggableCollection(
-            $this->connection, $name, $this, $this->eventManager, $this->cmd, $this->loggerCallable
+            $this->connection, $name, $this, $this->eventManager, $this->cmd, $this->loggerCallable, $this->numRetries
         );
     }
 }


### PR DESCRIPTION
This improves recovery after a successful failover event. I tested this
with a Symfony2 app -- many requests succeeded even when the following
appeared in the MongoDB log:

```
problem detected during query over dev.item : { $err: "not master and slaveOk=false", code: 13435 }
```

See also:
http://stackoverflow.com/questions/13318321/symfony2-app-mongodb-replica-set-failover-requires-apach

I tried running unit tests, but I just got a segfault.
