### PR TITLE
Added ability to return documents without the id as the key in Cursor::toArray()

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -317,11 +317,11 @@ class Cursor implements Iterator
         return $this->mongoCursor->valid();
     }
 
-    public function toArray()
+    public function toArray($useKeys = true)
     {
         $cursor = $this;
-        return $this->retry(function() use ($cursor) {
-            return iterator_to_array($cursor);
+        return $this->retry(function() use ($cursor, $useKeys) {
+            return iterator_to_array($cursor, $useKeys);
         }, true);
     }
 

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -61,4 +61,21 @@ class CursorTest extends BaseTest
         $cursor = $collection->createQueryBuilder()->getQuery()->execute();
         $this->assertNull($cursor->getSingleResult());
     }
+
+    public function testToArray()
+    {
+        $this->assertEquals(
+            array(
+                (string) $this->doc1['_id'] => $this->doc1,
+                (string) $this->doc2['_id'] => $this->doc2,
+                (string) $this->doc3['_id'] => $this->doc3
+            ),
+            $this->cursor->toArray()
+        );
+    }
+
+    public function testToArrayWithoutKeys()
+    {
+        $this->assertEquals(array($this->doc1, $this->doc2, $this->doc3), $this->cursor->toArray(false));
+    }
 }


### PR DESCRIPTION
I didn't pass this along to the eager cursor, but can if it's necessary.

It beats doing

``` php
return [
    'data' => array_values($cursor->toArray())
];
```

every time I want to remove the document ids from the array!

:)
