### PR TITLE
Make builder selectSlice command work if limit is null

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -354,9 +354,9 @@ class Builder
      */
     public function selectSlice($fieldName, $skip, $limit = null)
     {
-        $slice = array($skip);
+        $slice = $skip;
         if ($limit !== null) {
-            $slice[] = $limit;
+            $slice = array($skip, $limit);
         }
         $this->query['select'][$fieldName] = array($this->cmd . 'slice' => $slice);
         return $this;


### PR DESCRIPTION
Make selectSlice work if limit is null.
Allow negative slice in order to return the last n items in array.
