### PR TITLE
Implement Collection::aggregate() helper

### DIFF
--- a/lib/Doctrine/MongoDB/Event/AggregateEventArgs.php
+++ b/lib/Doctrine/MongoDB/Event/AggregateEventArgs.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\MongoDB\Event;
+
+use Doctrine\Common\EventArgs as BaseEventArgs;
+
+/**
+ * Aggregation event args.
+ *
+ * @license     http://www.opensource.org/licenses/mit-license.php MIT
+ * @link        www.doctrine-project.com
+ * @since       1.1
+ * @author      Jeremy Mikola <jmikola@gmail.com>
+ */
+class AggregateEventArgs extends BaseEventArgs
+{
+    private $invoker;
+    private $pipeline;
+
+    public function __construct($invoker, array &$pipeline)
+    {
+        $this->invoker = $invoker;
+        $this->pipeline = $pipeline;
+    }
+
+    public function getPipeline()
+    {
+        return $this->pipeline;
+    }
+}

--- a/lib/Doctrine/MongoDB/Events.php
+++ b/lib/Doctrine/MongoDB/Events.php
@@ -35,6 +35,9 @@ final class Events
 {
     private function __construct() {}
 
+    const preAggregate = 'collectionPreAggregate';
+    const postAggregate = 'collectionPostAggregate';
+
     const preBatchInsert = 'collectionPreBatchInsert';
     const postBatchInsert = 'collectionPostBatchInsert';
 

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -3,14 +3,105 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\Common\EventManager;
+use Doctrine\MongoDB\ArrayIterator;
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Database;
+use Doctrine\MongoDB\Events;
+use Doctrine\MongoDB\Event\AggregateEventArgs;
+use Doctrine\MongoDB\Event\EventArgs;
 use MongoCollection;
 
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
     const collectionName = 'collection';
+
+    public function testAggregateWithPipelineArgument()
+    {
+        $pipeline = array(
+            array('$match' => array('_id' => 'bar')),
+            array('$project' => array('_id' => 1)),
+        );
+        $aggregated = array(array('_id' => 'bar'));
+
+        $database = $this->getMockDatabase();
+        $database->expects($this->once())
+            ->method('command')
+            ->with(array('aggregate' => self::collectionName, 'pipeline' => $pipeline))
+            ->will($this->returnValue(array('ok' => 1, 'result' => $aggregated)));
+
+        $coll = $this->getTestCollection($this->getMockConnection(), $this->getMockMongoCollection(), $database);
+        $result = $coll->aggregate($pipeline);
+
+        $this->assertInstanceOf('Doctrine\MongoDB\ArrayIterator', $result);
+        $this->assertEquals($aggregated, $result->toArray());
+    }
+
+    public function testAggregateWithOperatorArguments()
+    {
+        $firstOp = array('$match' => array('_id' => 'bar'));
+        $secondOp = array('$project' => array('_id' => 1));
+        $aggregated = array(array('_id' => 'bar'));
+
+        $database = $this->getMockDatabase();
+        $database->expects($this->once())
+            ->method('command')
+            ->with(array('aggregate' => self::collectionName, 'pipeline' => array($firstOp, $secondOp)))
+            ->will($this->returnValue(array('ok' => 1, 'result' => $aggregated)));
+
+        $coll = $this->getTestCollection($this->getMockConnection(), $this->getMockMongoCollection(), $database);
+        $result = $coll->aggregate($firstOp, $secondOp);
+
+        $this->assertInstanceOf('Doctrine\MongoDB\ArrayIterator', $result);
+        $this->assertEquals($aggregated, $result->toArray());
+    }
+
+    public function testAggregateDispatchesEvents()
+    {
+        $pipeline = array(array('$match' => array('_id' => 'bar')));
+        $aggregated = array(array('_id' => 'bar'));
+
+        $eventManager = $this->getMockEventManager();
+
+        $database = $this->getMockDatabase();
+        $database->expects($this->once())
+            ->method('command')
+            ->with(array('aggregate' => self::collectionName, 'pipeline' => $pipeline))
+            ->will($this->returnValue(array('ok' => 1, 'result' => $aggregated)));
+
+        $coll = $this->getTestCollection($this->getMockConnection(), $this->getMockMongoCollection(), $database, $eventManager);
+
+        $this->expectEvents($eventManager, array(
+            array(Events::preAggregate, new AggregateEventArgs($coll, $pipeline)),
+            array(Events::postAggregate, $this->callback(function($v) use ($coll, $aggregated) {
+                return $v instanceof EventArgs &&
+                    $v->getInvoker() === $coll &&
+                    $v->getData() instanceof ArrayIterator &&
+                    $v->getData()->toArray() === $aggregated;
+            })),
+        ));
+
+        $result = $coll->aggregate($pipeline);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage foo
+     */
+    public function testAggregateShouldThrowExceptionOnError()
+    {
+        $pipeline = array(array('$invalidOp' => true));
+
+        $database = $this->getMockDatabase();
+        $database->expects($this->once())
+            ->method('command')
+            ->with(array('aggregate' => self::collectionName, 'pipeline' => $pipeline))
+            ->will($this->returnValue(array('ok' => 0, 'errmsg' => 'foo')));
+
+        $coll = $this->getTestCollection($this->getMockConnection(), $this->getMockMongoCollection(), $database);
+
+        $result = $coll->aggregate($pipeline);
+    }
 
     public function testBatchInsert()
     {
@@ -523,6 +614,33 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $coll = $this->getTestCollection($this->getMockConnection(), $mongoCollection);
 
         $this->assertEquals(self::collectionName, $coll->__toString());
+    }
+
+    /**
+     * Expect events to be dispatched by the event manager in the given order.
+     *
+     * @param EventManager $em     EventManager mock
+     * @param array        $events Tuple of event name and dispatch argument
+     */
+    private function expectEvents(EventManager $em, array $events)
+    {
+        /* Each event should be a tuple consisting of the event name and the
+         * dispatched argument (e.g. EventArgs).
+         *
+         * For each event, expect a call to hasListeners() immediately followed
+         * by a call to dispatchEvent(). The dispatch argument is passed as-is
+         * to with(), so constraints may be used (e.g. callback).
+         */
+        foreach ($events as $i => $event) {
+            $em->expects($this->at($i * 2))
+                ->method('hasListeners')
+                ->with($event[0])
+                ->will($this->returnValue(true));
+
+            $em->expects($this->at($i * 2 + 1))
+                ->method('dispatchEvent')
+                ->with($event[0], $event[1]);
+        }
     }
 
     private function getMockConnection()


### PR DESCRIPTION
See: #89. This adds a `Collection::aggregate()` method, along with relevant pre/post events.

Additionally, it includes some refactoring to CollectionTest and should facilitate easier testing of event dispatching for other Collection methods down the line.
