### PR TITLE
Added getter and setter for sorts to use with ODM Document Persister

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -341,6 +341,17 @@ class Cursor implements Iterator
         return $this;
     }
 
+    public function getSorts()
+    {
+        return $this->sorts;
+    }
+
+    public function setSorts($sorts)
+    {
+        $this->sorts = $sorts;
+        return $this;
+    }
+
     public function sort($fields)
     {
         foreach ($fields as $fieldName => $order) {


### PR DESCRIPTION
The ODM DocumentPersister private function wrapCursor(BaseCursor $cursor) doesn't set sorts.  This adds getter and setter for sorts.
