### PR TITLE
Clean up Cursor and EagerCursor docs and tests

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -76,26 +76,49 @@ class Cursor implements Iterator
         $this->numRetries = (integer) $numRetries;
     }
 
+    /**
+     * Return the database connection for this cursor.
+     *
+     * @return Connection
+     */
     public function getConnection()
     {
         return $this->connection;
     }
 
+    /**
+     * Return the collection for this cursor.
+     *
+     * @return Collection
+     */
     public function getCollection()
     {
         return $this->collection;
     }
 
+    /**
+     * Return the query.
+     *
+     * @return array
+     */
     public function getQuery()
     {
         return $this->query;
     }
 
+    /**
+     * Return the fields (projection).
+     *
+     * @return array
+     */
     public function getFields()
     {
         return $this->fields;
     }
 
+    /**
+     * Recreates the internal MongoCursor.
+     */
     public function recreate()
     {
         $this->mongoCursor = $this->collection->getMongoCollection()->find($this->query, $this->fields);
@@ -137,13 +160,17 @@ class Cursor implements Iterator
     /**
      * Returns the MongoCursor instance being wrapped.
      *
-     * @return MongoCursor $mongoCursor The MongoCursor instance being wrapped.
+     * @return \MongoCursor $mongoCursor
      */
     public function getMongoCursor()
     {
         return $this->mongoCursor;
     }
 
+    /**
+     * @see \Iterator::current()
+     * @see \MongoCursor::current()
+     */
     public function current()
     {
         $current = $this->mongoCursor->current();
@@ -155,16 +182,26 @@ class Cursor implements Iterator
         return $current;
     }
 
+    /**
+     * @see \Iterator::key()
+     * @see \MongoCursor::dead()
+     */
     public function key()
     {
         return $this->mongoCursor->key();
     }
 
+    /**
+     * @see \MongoCursor::dead()
+     */
     public function dead()
     {
         return $this->mongoCursor->dead();
     }
 
+    /**
+     * @see \MongoCursor::explain()
+     */
     public function explain()
     {
         $cursor = $this;
@@ -173,6 +210,9 @@ class Cursor implements Iterator
         }, true);
     }
 
+    /**
+     * @see \MongoCursor::fields()
+     */
     public function fields(array $f)
     {
         $this->fields = $f;
@@ -180,6 +220,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::getNext()
+     */
     public function getNext()
     {
         $cursor = $this;
@@ -194,6 +237,9 @@ class Cursor implements Iterator
         return $next;
     }
 
+    /**
+     * @see \MongoCursor::hasNext()
+     */
     public function hasNext()
     {
         $cursor = $this;
@@ -202,6 +248,9 @@ class Cursor implements Iterator
         }, false);
     }
 
+    /**
+     * @see \MongoCursor::hint()
+     */
     public function hint(array $keyPattern)
     {
         $this->hints[] = $keyPattern;
@@ -209,6 +258,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::immortal()
+     */
     public function immortal($liveForever = true)
     {
         $liveForever = (boolean) $liveForever;
@@ -217,11 +269,18 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::info()
+     */
     public function info()
     {
         return $this->mongoCursor->info();
     }
 
+    /**
+     * @see \Iterator::rewind()
+     * @see \MongoCursor::rewind()
+     */
     public function rewind()
     {
         $cursor = $this;
@@ -230,6 +289,10 @@ class Cursor implements Iterator
         }, false);
     }
 
+    /**
+     * @see \Iterator::next()
+     * @see \MongoCursor::next()
+     */
     public function next()
     {
         $cursor = $this;
@@ -238,11 +301,18 @@ class Cursor implements Iterator
         }, false);
     }
 
+    /**
+     * @see \MongoCursor::reset()
+     */
     public function reset()
     {
         return $this->mongoCursor->reset();
     }
 
+    /**
+     * @see \Countable::count()
+     * @see \MongoCursor::count()
+     */
     public function count($foundOnly = false)
     {
         $cursor = $this;
@@ -251,6 +321,9 @@ class Cursor implements Iterator
         }, true);
     }
 
+    /**
+     * @see \MongoCursor::addOption()
+     */
     public function addOption($key, $value)
     {
         $this->options[$key] = $value;
@@ -258,6 +331,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::batchSize()
+     */
     public function batchSize($num)
     {
         $limit = (integer) $num;
@@ -266,6 +342,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::limit()
+     */
     public function limit($num)
     {
         $limit = (integer) $num;
@@ -274,6 +353,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::skip()
+     */
     public function skip($num)
     {
         $num = (integer) $num;
@@ -282,6 +364,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::slaveOkay()
+     */
     public function slaveOkay($ok = true)
     {
         $ok = (boolean) $ok;
@@ -324,6 +409,9 @@ class Cursor implements Iterator
         }
     }
 
+    /**
+     * @see \MongoCursor::snapshot()
+     */
     public function snapshot()
     {
         $this->snapshot = true;
@@ -331,6 +419,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::sort()
+     */
     public function sort($fields)
     {
         foreach ($fields as $fieldName => $order) {
@@ -344,6 +435,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::tailable()
+     */
     public function tailable($tail = true)
     {
         $tail = (boolean) $tail;
@@ -352,6 +446,9 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \MongoCursor::timeout()
+     */
     public function timeout($ms)
     {
         $this->timeout = (integer) $ms;
@@ -359,11 +456,18 @@ class Cursor implements Iterator
         return $this;
     }
 
+    /**
+     * @see \Iterator::valid()
+     * @see \MongoCursor::valid()
+     */
     public function valid()
     {
         return $this->mongoCursor->valid();
     }
 
+    /**
+     * @see Iterator::toArray()
+     */
     public function toArray($useKeys = true)
     {
         $cursor = $this;
@@ -373,9 +477,7 @@ class Cursor implements Iterator
     }
 
     /**
-     * Get the first single result from the cursor.
-     *
-     * @return array $document  The single document.
+     * @see Iterator::getSingleResult()
      */
     public function getSingleResult()
     {

--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -20,7 +20,8 @@
 namespace Doctrine\MongoDB;
 
 /**
- * EagerCursor class.
+ * EagerCursor wraps a Cursor instance and fetches all of its results upon
+ * initialization.
  *
  * @license     http://www.opensource.org/licenses/mit-license.php MIT
  * @link        www.doctrine-project.org
@@ -29,82 +30,128 @@ namespace Doctrine\MongoDB;
  */
 class EagerCursor implements Iterator
 {
-    /** @var object Doctrine\MongoDB\Cursor */
+    /**
+     * @var Cursor
+     */
     protected $cursor;
 
-    /** @var array Array of data from Cursor to iterate over */
+    /**
+     * @var array
+     */
     protected $data = array();
 
-    /** @var bool Whether or not the EagerCursor has been initialized */
+    /**
+     * @var boolean
+     */
     protected $initialized = false;
 
+    /**
+     * Constructor.
+     *
+     * @param Cursor $cursor Cursor to wrap
+     */
     public function __construct(Cursor $cursor)
     {
         $this->cursor = $cursor;
     }
 
+    /**
+     * Return the wrapped cursor.
+     *
+     * @return Cursor
+     */
     public function getCursor()
     {
         return $this->cursor;
     }
 
+    /**
+     * Return whether the internal data has been initialized.
+     *
+     * @return boolean
+     */
     public function isInitialized()
     {
         return $this->initialized;
     }
 
+    /**
+     * Initialize the internal data by converting the cursor to an array.
+     */
     public function initialize()
     {
         if ($this->initialized === false) {
             $this->data = $this->cursor->toArray();
-            unset($this->cursor);
         }
         $this->initialized = true;
     }
 
+    /**
+     * @see \Iterator::rewind()
+     */
     public function rewind()
     {
         $this->initialize();
         reset($this->data);
     }
-  
+
+    /**
+     * @see \Iterator::current()
+     */
     public function current()
     {
         $this->initialize();
         return current($this->data);
     }
-  
-    public function key() 
+
+    /**
+     * @see \Iterator::key()
+     */
+    public function key()
     {
         $this->initialize();
         return key($this->data);
     }
-  
-    public function next() 
+
+    /**
+     * @see \Iterator::next()
+     */
+    public function next()
     {
         $this->initialize();
-        return next($this->data);
+        next($this->data);
     }
-  
+
+    /**
+     * @see \Iterator::valid()
+     */
     public function valid()
     {
         $this->initialize();
-        $key = key($this->data);
-        return ($key !== NULL && $key !== FALSE);
+        return key($this->data) !== null;
     }
 
+    /**
+     * @see \Countable::count()
+     */
     public function count()
     {
         $this->initialize();
         return count($this->data);
     }
 
+    /**
+     * @see Iterator::toArray()
+     */
     public function toArray()
     {
         $this->initialize();
         return $this->data;
     }
 
+    /**
+     * @see Iterator::getSingleResult()
+     */
     public function getSingleResult()
     {
         $this->initialize();

--- a/lib/Doctrine/MongoDB/Iterator.php
+++ b/lib/Doctrine/MongoDB/Iterator.php
@@ -29,6 +29,17 @@ namespace Doctrine\MongoDB;
  */
 interface Iterator extends \Iterator, \Countable
 {
+    /**
+     * Return all elements as an array.
+     *
+     * @return array
+     */
     function toArray();
+
+    /**
+     * Return the first element from the result set.
+     *
+     * @return array|object|null
+     */
     function getSingleResult();
 }

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -11,7 +11,6 @@ class CursorTest extends BaseTest
     private $doc1;
     private $doc2;
     private $doc3;
-
     private $cursor;
 
     public function setUp()
@@ -22,7 +21,8 @@ class CursorTest extends BaseTest
         $this->doc2 = array('name' => 'B');
         $this->doc3 = array('name' => 'C');
 
-        $collection = $this->conn->selectCollection(self::$dbName, 'docs');
+        $collection = $this->conn->selectCollection(self::$dbName, 'CursorTest');
+        $collection->drop();
         $collection->insert($this->doc1);
         $collection->insert($this->doc2);
         $collection->insert($this->doc3);


### PR DESCRIPTION
Additionally, there were two small changes to EagerCursor::valid() (only checking key() for null, in accordance with PHP documentation) and next() (remove return statement).
