### PR TITLE
Remove $cmd args/properties and deprecate mongoCmd option

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -71,13 +71,6 @@ class Collection
     protected $eventManager;
 
     /**
-     * MongoDB command prefix.
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * Number of times to retry queries.
      *
      * @var integer
@@ -91,16 +84,14 @@ class Collection
      * @param string          $name       The collection name
      * @param Database        $database   Database to which this collection belongs
      * @param EventManager    $evm        EventManager instance
-     * @param string          $cmd        MongoDB command prefix
      * @param boolean|integer $numRetries Number of times to retry queries
      */
-    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $cmd, $numRetries = 0)
+    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $numRetries = 0)
     {
         $this->connection = $connection;
         $this->name = $name;
         $this->database = $database;
         $this->eventManager = $evm;
-        $this->cmd = $cmd;
         $this->numRetries = (integer) $numRetries;
     }
 
@@ -205,7 +196,7 @@ class Collection
      */
     public function createQueryBuilder()
     {
-        return new Query\Builder($this->database, $this, $this->cmd);
+        return new Query\Builder($this->database, $this);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Configuration.php
+++ b/lib/Doctrine/MongoDB/Configuration.php
@@ -61,20 +61,24 @@ class Configuration
     /**
      * Get the MongoDB command prefix.
      *
+     * @deprecated 1.1 No longer supported; will be removed for 1.2
      * @return string
      */
     public function getMongoCmd()
     {
+        trigger_error('MongoDB command prefix option is no longer used', E_USER_DEPRECATED);
         return $this->attributes['mongoCmd'];
     }
 
     /**
      * Set the MongoDB command prefix.
      *
+     * @deprecated 1.1 No longer supported; will be removed for 1.2
      * @param string $cmd
      */
     public function setMongoCmd($cmd)
     {
+        trigger_error('MongoDB command prefix option is no longer used', E_USER_DEPRECATED);
         $this->attributes['mongoCmd'] = $cmd;
     }
 

--- a/lib/Doctrine/MongoDB/Connection.php
+++ b/lib/Doctrine/MongoDB/Connection.php
@@ -66,13 +66,6 @@ class Connection
     protected $eventManager;
 
     /**
-     * MongoDB command prefix.
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * Constructor.
      *
      * If $server is an existing MongoClient instance, the $options parameter
@@ -93,7 +86,6 @@ class Connection
         }
         $this->config = $config ? $config : new Configuration();
         $this->eventManager = $evm ? $evm : new EventManager();
-        $this->cmd = $this->config->getMongoCmd();
     }
 
     /**
@@ -416,9 +408,9 @@ class Connection
         $numRetries = $this->config->getRetryQuery();
         if (null !== $this->config->getLoggerCallable()) {
             return new LoggableDatabase(
-                $this, $name, $this->eventManager, $this->cmd, $numRetries, $this->config->getLoggerCallable()
+                $this, $name, $this->eventManager, $numRetries, $this->config->getLoggerCallable()
             );
         }
-        return new Database($this, $name, $this->eventManager, $this->cmd, $numRetries);
+        return new Database($this, $name, $this->eventManager, $numRetries);
     }
 }

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -59,13 +59,6 @@ class Database
     protected $eventManager;
 
     /**
-     * MongoDB command prefix.
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * Number of times to retry queries.
      *
      * @var integer
@@ -78,15 +71,13 @@ class Database
      * @param Connection      $connection Connection used to create Collections
      * @param string          $name       The database name
      * @param EventManager    $evm        EventManager instance
-     * @param string          $cmd        MongoDB command prefix
      * @param boolean|integer $numRetries Number of times to retry queries
      */
-    public function __construct(Connection $connection, $name, EventManager $evm, $cmd, $numRetries = 0)
+    public function __construct(Connection $connection, $name, EventManager $evm, $numRetries = 0)
     {
         $this->connection = $connection;
         $this->name = $name;
         $this->eventManager = $evm;
-        $this->cmd = $cmd;
         $this->numRetries = (integer) $numRetries;
     }
 
@@ -551,7 +542,7 @@ class Database
      */
     protected function doGetGridFS($prefix)
     {
-        return new GridFS($this->connection, $prefix, $this, $this->eventManager, $this->cmd);
+        return new GridFS($this->connection, $prefix, $this, $this->eventManager);
     }
 
     /**
@@ -563,7 +554,7 @@ class Database
      */
     protected function doSelectCollection($name)
     {
-        return new Collection($this->connection, $name, $this, $this->eventManager, $this->cmd, $this->numRetries);
+        return new Collection($this->connection, $name, $this, $this->eventManager, $this->numRetries);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/GridFS.php
+++ b/lib/Doctrine/MongoDB/GridFS.php
@@ -196,8 +196,8 @@ class GridFS extends Collection
      */
     protected function doUpdate(array $query, array $newObj, array $options = array())
     {
-        $file = isset($newObj[$this->cmd.'set']['file']) ? $newObj[$this->cmd.'set']['file'] : null;
-        unset($newObj[$this->cmd.'set']['file']);
+        $file = isset($newObj['$set']['file']) ? $newObj['$set']['file'] : null;
+        unset($newObj['$set']['file']);
 
         if ($file === null) {
             $file = isset($newObj['file']) ? $newObj['file'] : null;
@@ -207,8 +207,8 @@ class GridFS extends Collection
         /* Before we inspect $newObj, remove an empty $set operator we may have
          * left behind due to extracting the file field above.
          */
-        if (empty($newObj[$this->cmd.'set'])) {
-            unset($newObj[$this->cmd.'set']);
+        if (empty($newObj['$set'])) {
+            unset($newObj['$set']);
         }
 
         /* Determine if $newObj includes atomic modifiers, which will tell us if
@@ -218,7 +218,7 @@ class GridFS extends Collection
         $newObjHasModifiers = false;
 
         foreach (array_keys($newObj) as $key) {
-            if ($this->cmd === $key[0]) {
+            if ('$' === $key[0]) {
                 $newObjHasModifiers = true;
             }
         }

--- a/lib/Doctrine/MongoDB/LoggableCollection.php
+++ b/lib/Doctrine/MongoDB/LoggableCollection.php
@@ -44,17 +44,16 @@ class LoggableCollection extends Collection implements Loggable
      * @param string          $name           The collection name
      * @param Database        $database       Database to which this collection belongs
      * @param EventManager    $evm            EventManager instance
-     * @param string          $cmd            MongoDB command prefix
      * @param callable        $loggerCallable The logger callable
      * @param boolean|integer $numRetries     Number of times to retry queries
      */
-    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $cmd, $loggerCallable, $numRetries = 0)
+    public function __construct(Connection $connection, $name, Database $database, EventManager $evm, $loggerCallable, $numRetries = 0)
     {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
         $this->loggerCallable = $loggerCallable;
-        parent::__construct($connection, $name, $database, $evm, $cmd, $numRetries);
+        parent::__construct($connection, $name, $database, $evm, $numRetries);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -43,16 +43,15 @@ class LoggableDatabase extends Database implements Loggable
      * @param Connection      $connection     Connection used to create Collections
      * @param string          $name           The database name
      * @param EventManager    $evm            EventManager instance
-     * @param string          $cmd            MongoDB command prefix
      * @param boolean|integer $numRetries     Number of times to retry queries
      * @param callable        $loggerCallable The logger callable
      */
-    public function __construct(Connection $connection, $name, EventManager $evm, $cmd, $numRetries, $loggerCallable)
+    public function __construct(Connection $connection, $name, EventManager $evm, $numRetries, $loggerCallable)
     {
         if ( ! is_callable($loggerCallable)) {
             throw new \InvalidArgumentException('$loggerCallable must be a valid callback');
         }
-        parent::__construct($connection, $name, $evm, $cmd, $numRetries);
+        parent::__construct($connection, $name, $evm, $numRetries);
         $this->loggerCallable = $loggerCallable;
     }
 
@@ -165,7 +164,7 @@ class LoggableDatabase extends Database implements Loggable
     protected function doSelectCollection($name)
     {
         return new LoggableCollection(
-            $this->connection, $name, $this, $this->eventManager, $this->cmd, $this->loggerCallable, $this->numRetries
+            $this->connection, $name, $this, $this->eventManager, $this->loggerCallable, $this->numRetries
         );
     }
 }

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -55,13 +55,6 @@ class Builder
     protected $query = array('type' => Query::TYPE_FIND);
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * The Expr instance used for building this query.
      *
      * This object includes the query criteria and the "new object" used for
@@ -75,15 +68,12 @@ class Builder
      * Create a new query builder.
      *
      * @param Database $database
-     * @param Collection $collection
-     * @param string $cmd
      */
-    public function __construct(Database $database, Collection $collection, $cmd)
+    public function __construct(Database $database, Collection $collection)
     {
         $this->database = $database;
         $this->collection = $collection;
-        $this->expr = new Expr($cmd);
-        $this->cmd = $cmd;
+        $this->expr = new Expr();
     }
 
     /**
@@ -336,7 +326,7 @@ class Builder
      */
     public function expr()
     {
-        return new Expr($this->cmd);
+        return new Expr();
     }
 
     /**
@@ -598,7 +588,7 @@ class Builder
         $query = $this->query;
         $query['query'] = $this->expr->getQuery();
         $query['newObj'] = $this->expr->getNewObj();
-        return new Query($this->database, $this->collection, $query, $options, $this->cmd);
+        return new Query($this->database, $this->collection, $query, $options);
     }
 
     /**
@@ -1221,7 +1211,7 @@ class Builder
         if ($expression instanceof Expr) {
             $expression = $expression->getQuery();
         }
-        $this->query['select'][$fieldName] = array($this->cmd . 'elemMatch' => $expression);
+        $this->query['select'][$fieldName] = array('$elemMatch' => $expression);
         return $this;
     }
 
@@ -1248,7 +1238,7 @@ class Builder
         if ($limit !== null) {
             $slice = array($slice, $limit);
         }
-        $this->query['select'][$fieldName] = array($this->cmd . 'slice' => $slice);
+        $this->query['select'][$fieldName] = array('$slice' => $slice);
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -34,13 +34,6 @@ use LogicException;
 class Expr
 {
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * The query criteria array.
      *
      * @var string
@@ -64,16 +57,6 @@ class Expr
     protected $currentField;
 
     /**
-     * Constructor.
-     *
-     * @param string $cmd
-     */
-    public function __construct($cmd)
-    {
-        $this->cmd = $cmd;
-    }
-
-    /**
      * Add an $and clause to the current query.
      *
      * @see Builder::addAnd()
@@ -83,7 +66,7 @@ class Expr
      */
     public function addAnd($expression)
     {
-        $this->query[$this->cmd . 'and'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        $this->query['$and'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
         return $this;
     }
 
@@ -105,7 +88,7 @@ class Expr
     public function addManyToSet(array $values)
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'addToSet'][$this->currentField] = array($this->cmd . 'each' => $values);
+        $this->newObj['$addToSet'][$this->currentField] = array('$each' => $values);
         return $this;
     }
 
@@ -119,7 +102,7 @@ class Expr
      */
     public function addNor($expression)
     {
-        $this->query[$this->cmd . 'nor'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        $this->query['$nor'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
         return $this;
     }
 
@@ -133,7 +116,7 @@ class Expr
      */
     public function addOr($expression)
     {
-        $this->query[$this->cmd . 'or'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        $this->query['$or'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
         return $this;
     }
 
@@ -161,7 +144,7 @@ class Expr
         }
 
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'addToSet'][$this->currentField] = $valueOrExpression;
+        $this->newObj['$addToSet'][$this->currentField] = $valueOrExpression;
         return $this;
     }
 
@@ -175,7 +158,7 @@ class Expr
      */
     public function all(array $values)
     {
-        return $this->operator($this->cmd . 'all', (array) $values);
+        return $this->operator('$all', (array) $values);
     }
 
     /**
@@ -188,7 +171,7 @@ class Expr
      */
     public function each(array $values)
     {
-        return $this->operator($this->cmd . 'each', $values);
+        return $this->operator('$each', $values);
     }
 
     /**
@@ -201,7 +184,7 @@ class Expr
      */
     public function elemMatch($expression)
     {
-        return $this->operator($this->cmd . 'elemMatch', $expression instanceof Expr ? $expression->getQuery() : $expression);
+        return $this->operator('$elemMatch', $expression instanceof Expr ? $expression->getQuery() : $expression);
     }
 
     /**
@@ -231,7 +214,7 @@ class Expr
      */
     public function exists($bool)
     {
-        return $this->operator($this->cmd . 'exists', (boolean) $bool);
+        return $this->operator('$exists', (boolean) $bool);
     }
 
     /**
@@ -264,7 +247,7 @@ class Expr
             $geometry = $geometry->jsonSerialize();
         }
 
-        return $this->operator($this->cmd . 'geoIntersects', array($this->cmd . 'geometry' => $geometry));
+        return $this->operator('$geoIntersects', array('$geometry' => $geometry));
     }
 
     /**
@@ -284,7 +267,7 @@ class Expr
             $geometry = $geometry->jsonSerialize();
         }
 
-        return $this->operator($this->cmd . 'geoWithin', array($this->cmd . 'geometry' => $geometry));
+        return $this->operator('$geoWithin', array('$geometry' => $geometry));
     }
 
     /**
@@ -306,9 +289,9 @@ class Expr
      */
     public function geoWithinBox($x1, $y1, $x2, $y2)
     {
-        $shape = array($this->cmd . 'box' => array(array($x1, $y1), array($x2, $y2)));
+        $shape = array('$box' => array(array($x1, $y1), array($x2, $y2)));
 
-        return $this->operator($this->cmd . 'geoWithin', $shape);
+        return $this->operator('$geoWithin', $shape);
     }
 
     /**
@@ -326,9 +309,9 @@ class Expr
      */
     public function geoWithinCenter($x, $y, $radius)
     {
-        $shape = array($this->cmd . 'center' => array(array($x, $y), $radius));
+        $shape = array('$center' => array(array($x, $y), $radius));
 
-        return $this->operator($this->cmd . 'geoWithin', $shape);
+        return $this->operator('$geoWithin', $shape);
     }
 
     /**
@@ -345,9 +328,9 @@ class Expr
      */
     public function geoWithinCenterSphere($x, $y, $radius)
     {
-        $shape = array($this->cmd . 'centerSphere' => array(array($x, $y), $radius));
+        $shape = array('$centerSphere' => array(array($x, $y), $radius));
 
-        return $this->operator($this->cmd . 'geoWithin', $shape);
+        return $this->operator('$geoWithin', $shape);
     }
 
     /**
@@ -373,9 +356,9 @@ class Expr
             throw new InvalidArgumentException('Polygon must be defined by three or more points.');
         }
 
-        $shape = array($this->cmd . 'polygon' => func_get_args());
+        $shape = array('$polygon' => func_get_args());
 
-        return $this->operator($this->cmd . 'geoWithin', $shape);
+        return $this->operator('$geoWithin', $shape);
     }
 
     /**
@@ -444,7 +427,7 @@ class Expr
      */
     public function gt($value)
     {
-        return $this->operator($this->cmd . 'gt', $value);
+        return $this->operator('$gt', $value);
     }
 
     /**
@@ -457,7 +440,7 @@ class Expr
      */
     public function gte($value)
     {
-        return $this->operator($this->cmd . 'gte', $value);
+        return $this->operator('$gte', $value);
     }
 
     /**
@@ -470,7 +453,7 @@ class Expr
      */
     public function in(array $values)
     {
-        return $this->operator($this->cmd . 'in', $values);
+        return $this->operator('$in', $values);
     }
 
     /**
@@ -486,7 +469,7 @@ class Expr
     public function inc($value)
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'inc'][$this->currentField] = $value;
+        $this->newObj['$inc'][$this->currentField] = $value;
         return $this;
     }
 
@@ -500,7 +483,7 @@ class Expr
      */
     public function lt($value)
     {
-        return $this->operator($this->cmd . 'lt', $value);
+        return $this->operator('$lt', $value);
     }
 
     /**
@@ -513,7 +496,7 @@ class Expr
      */
     public function lte($value)
     {
-        return $this->operator($this->cmd . 'lte', $value);
+        return $this->operator('$lte', $value);
     }
 
     /**
@@ -536,18 +519,18 @@ class Expr
             $query = &$this->query;
         }
 
-        if ( ! isset($query[$this->cmd . 'near']) && ! isset($query[$this->cmd . 'nearSphere'])) {
+        if ( ! isset($query['$near']) && ! isset($query['$nearSphere'])) {
             throw new BadMethodCallException(
                 'This method requires a $near or $nearSphere operator (call near() or nearSphere() first)'
             );
         }
 
-        if (isset($query[$this->cmd . 'near'][$this->cmd . 'geometry'])) {
-            $query[$this->cmd . 'near'][$this->cmd . 'maxDistance'] = $maxDistance;
-        } elseif (isset($query[$this->cmd . 'nearSphere'][$this->cmd . 'geometry'])) {
-            $query[$this->cmd . 'nearSphere'][$this->cmd . 'maxDistance'] = $maxDistance;
+        if (isset($query['$near']['$geometry'])) {
+            $query['$near']['$maxDistance'] = $maxDistance;
+        } elseif (isset($query['$nearSphere']['$geometry'])) {
+            $query['$nearSphere']['$maxDistance'] = $maxDistance;
         } else {
-            $query[$this->cmd . 'maxDistance'] = $maxDistance;
+            $query['$maxDistance'] = $maxDistance;
         }
 
         return $this;
@@ -563,7 +546,7 @@ class Expr
      */
     public function mod($mod)
     {
-        return $this->operator($this->cmd . 'mod', $mod);
+        return $this->operator('$mod', $mod);
     }
 
     /**
@@ -586,10 +569,10 @@ class Expr
         }
 
         if (is_array($x)) {
-            return $this->operator($this->cmd . 'near', array($this->cmd . 'geometry' => $x));
+            return $this->operator('$near', array('$geometry' => $x));
         }
 
-        return $this->operator($this->cmd . 'near', array($x, $y));
+        return $this->operator('$near', array($x, $y));
     }
 
     /**
@@ -612,10 +595,10 @@ class Expr
         }
 
         if (is_array($x)) {
-            return $this->operator($this->cmd . 'nearSphere', array($this->cmd . 'geometry' => $x));
+            return $this->operator('$nearSphere', array('$geometry' => $x));
         }
 
-        return $this->operator($this->cmd . 'nearSphere', array($x, $y));
+        return $this->operator('$nearSphere', array($x, $y));
     }
 
     /**
@@ -628,7 +611,7 @@ class Expr
      */
     public function not($expression)
     {
-        return $this->operator($this->cmd . 'not', $expression instanceof Expr ? $expression->getQuery() : $expression);
+        return $this->operator('$not', $expression instanceof Expr ? $expression->getQuery() : $expression);
     }
 
     /**
@@ -641,7 +624,7 @@ class Expr
      */
     public function notEqual($value)
     {
-        return $this->operator($this->cmd . 'ne', $value);
+        return $this->operator('$ne', $value);
     }
 
     /**
@@ -654,7 +637,7 @@ class Expr
      */
     public function notIn(array $values)
     {
-        return $this->operator($this->cmd . 'nin', $values);
+        return $this->operator('$nin', $values);
     }
 
     /**
@@ -687,7 +670,7 @@ class Expr
     public function popFirst()
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'pop'][$this->currentField] = 1;
+        $this->newObj['$pop'][$this->currentField] = 1;
         return $this;
     }
 
@@ -701,7 +684,7 @@ class Expr
     public function popLast()
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'pop'][$this->currentField] = -1;
+        $this->newObj['$pop'][$this->currentField] = -1;
         return $this;
     }
 
@@ -721,7 +704,7 @@ class Expr
         }
 
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'pull'][$this->currentField] = $valueOrExpression;
+        $this->newObj['$pull'][$this->currentField] = $valueOrExpression;
         return $this;
     }
 
@@ -737,7 +720,7 @@ class Expr
     public function pullAll(array $values)
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'pullAll'][$this->currentField] = $values;
+        $this->newObj['$pullAll'][$this->currentField] = $values;
         return $this;
     }
 
@@ -764,13 +747,13 @@ class Expr
     {
         if ($valueOrExpression instanceof Expr) {
             $valueOrExpression = array_merge(
-                array($this->cmd . 'each' => array()),
+                array('$each' => array()),
                 $valueOrExpression->getQuery()
             );
         }
 
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'push'][$this->currentField] = $valueOrExpression;
+        $this->newObj['$push'][$this->currentField] = $valueOrExpression;
         return $this;
     }
 
@@ -792,7 +775,7 @@ class Expr
     public function pushAll(array $values)
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'pushAll'][$this->currentField] = $values;
+        $this->newObj['$pushAll'][$this->currentField] = $values;
         return $this;
     }
 
@@ -809,7 +792,7 @@ class Expr
      */
     public function range($start, $end)
     {
-        return $this->operator($this->cmd . 'gte', $start)->operator($this->cmd . 'lt', $end);
+        return $this->operator('$gte', $start)->operator('$lt', $end);
     }
 
     /**
@@ -830,7 +813,7 @@ class Expr
         $this->requiresCurrentField();
 
         if ($atomic) {
-            $this->newObj[$this->cmd . 'set'][$this->currentField] = $value;
+            $this->newObj['$set'][$this->currentField] = $value;
             return $this;
         }
 
@@ -859,7 +842,7 @@ class Expr
      */
     public function size($size)
     {
-        return $this->operator($this->cmd . 'size', (integer) $size);
+        return $this->operator('$size', (integer) $size);
     }
 
     /**
@@ -875,7 +858,7 @@ class Expr
      */
     public function slice($slice)
     {
-        return $this->operator($this->cmd . 'slice', $slice);
+        return $this->operator('$slice', $slice);
     }
 
     /**
@@ -904,7 +887,7 @@ class Expr
             $sort[$fieldName] = (integer) $order;
         }
 
-        return $this->operator($this->cmd . 'sort', $sort);
+        return $this->operator('$sort', $sort);
     }
 
     /**
@@ -944,7 +927,7 @@ class Expr
             $type = isset($map[$type]) ? $map[$type] : $type;
         }
 
-        return $this->operator($this->cmd . 'type', $type);
+        return $this->operator('$type', $type);
     }
 
     /**
@@ -959,7 +942,7 @@ class Expr
     public function unsetField()
     {
         $this->requiresCurrentField();
-        $this->newObj[$this->cmd . 'unset'][$this->currentField] = 1;
+        $this->newObj['$unset'][$this->currentField] = 1;
         return $this;
     }
 
@@ -973,7 +956,7 @@ class Expr
      */
     public function where($javascript)
     {
-        $this->query[$this->cmd . 'where'] = $javascript;
+        $this->query['$where'] = $javascript;
         return $this;
     }
 
@@ -991,9 +974,9 @@ class Expr
      */
     public function withinBox($x1, $y1, $x2, $y2)
     {
-        $shape = array($this->cmd . 'box' => array(array($x1, $y1), array($x2, $y2)));
+        $shape = array('$box' => array(array($x1, $y1), array($x2, $y2)));
 
-        return $this->operator($this->cmd . 'within', $shape);
+        return $this->operator('$within', $shape);
     }
 
     /**
@@ -1009,9 +992,9 @@ class Expr
      */
     public function withinCenter($x, $y, $radius)
     {
-        $shape = array($this->cmd . 'center' => array(array($x, $y), $radius));
+        $shape = array('$center' => array(array($x, $y), $radius));
 
-        return $this->operator($this->cmd . 'within', $shape);
+        return $this->operator('$within', $shape);
     }
 
     /**
@@ -1027,9 +1010,9 @@ class Expr
      */
     public function withinCenterSphere($x, $y, $radius)
     {
-        $shape = array($this->cmd . 'centerSphere' => array(array($x, $y), $radius));
+        $shape = array('$centerSphere' => array(array($x, $y), $radius));
 
-        return $this->operator($this->cmd . 'within', $shape);
+        return $this->operator('$within', $shape);
     }
 
     /**
@@ -1053,9 +1036,9 @@ class Expr
             throw new InvalidArgumentException('Polygon must be defined by three or more points.');
         }
 
-        $shape = array($this->cmd . 'polygon' => func_get_args());
+        $shape = array('$polygon' => func_get_args());
 
-        return $this->operator($this->cmd . 'within', $shape);
+        return $this->operator('$within', $shape);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -73,13 +73,6 @@ class Query implements IteratorAggregate
     protected $query;
 
     /**
-     * Mongo command prefix
-     *
-     * @var string
-     */
-    protected $cmd;
-
-    /**
      * @var Iterator
      */
     protected $iterator;
@@ -98,10 +91,9 @@ class Query implements IteratorAggregate
      * @param Collection $collection
      * @param array $query
      * @param array $options
-     * @param string $cmd
      * @throws InvalidArgumentException if query type is invalid
      */
-    public function __construct(Database $database, Collection $collection, array $query, array $options, $cmd)
+    public function __construct(Database $database, Collection $collection, array $query, array $options)
     {
         switch ($query['type']) {
             case self::TYPE_FIND:
@@ -124,7 +116,6 @@ class Query implements IteratorAggregate
         $this->database   = $database;
         $this->collection = $collection;
         $this->query      = $query;
-        $this->cmd        = $cmd;
         $this->options    = $options;
     }
 

--- a/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionEventsTest.php
@@ -332,7 +332,7 @@ class CollectionEventsTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $collection = $this->getMockBuilder('Doctrine\MongoDB\Collection')
-            ->setConstructorArgs(array($c, self::collectionName, $db, $em, '$'))
+            ->setConstructorArgs(array($c, self::collectionName, $db, $em))
             ->setMethods(array_keys($methods))
             ->getMock();
 

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -853,7 +853,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $db = $db ?: $this->getMockDatabase();
         $em = $em ?: $this->getMockEventManager();
 
-        $collection = new TestCollectionStub($c, $mc->getName(), $db, $em, '$');
+        $collection = new TestCollectionStub($c, $mc->getName(), $db, $em);
         $collection->setMongoCollection($mc);
 
         return $collection;

--- a/tests/Doctrine/MongoDB/Tests/DatabaseEventsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseEventsTest.php
@@ -138,7 +138,7 @@ class DatabaseEventsTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $db = $this->getMockBuilder('Doctrine\MongoDB\Database')
-            ->setConstructorArgs(array($c, self::databaseName, $em, '$'))
+            ->setConstructorArgs(array($c, self::databaseName, $em))
             ->setMethods(array_keys($methods))
             ->getMock();
 

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -41,7 +41,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
                 ->with('foo', true, 10485760, 0);
         }
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
         $collection = $database->createCollection('foo', true, 10485760, 0);
 
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
@@ -60,7 +60,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
                 ->with('foo', true, 10485760, 0);
         }
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
         $collection = $database->createCollection('foo', array('capped' => true, 'size' => 10485760, 'autoIndexId' => false));
 
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
@@ -82,7 +82,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
             ->with(true)
             ->will($this->returnValue(false));
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
 
         $this->assertEquals(false, $database->getSlaveOkay());
         $this->assertEquals(false, $database->setSlaveOkay(true));
@@ -109,7 +109,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED)
             ->will($this->returnValue(false));
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
 
         $this->assertEquals(false, $database->setSlaveOkay(true));
     }
@@ -133,7 +133,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED, array(array('dc' => 'east')))
             ->will($this->returnValue(false));
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
 
         $this->assertEquals(true, $database->setSlaveOkay(true));
     }
@@ -154,7 +154,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
             ->with(\MongoClient::RP_SECONDARY_PREFERRED, array(array('dc' => 'east')))
             ->will($this->returnValue(true));
 
-        $database = new Database($this->connection, 'test', $this->getMockEventManager(), '$');
+        $database = new Database($this->connection, 'test', $this->getMockEventManager());
 
         $this->assertTrue($database->setReadPreference(\MongoClient::RP_PRIMARY));
         $this->assertTrue($database->setReadPreference(\MongoClient::RP_SECONDARY_PREFERRED, array(array('dc' => 'east'))));

--- a/tests/Doctrine/MongoDB/Tests/LoggableCollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableCollectionTest.php
@@ -41,6 +41,6 @@ class LoggableCollectionTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new LoggableCollection($c, self::collectionName, $db, $em, '$', $loggerCallable);
+        return new LoggableCollection($c, self::collectionName, $db, $em, $loggerCallable);
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/LoggableDatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableDatabaseTest.php
@@ -84,7 +84,7 @@ class LoggableDatabaseTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $db = new TestLoggableDatabaseStub($c, self::databaseName, $em, '$', 0, $loggerCallable);
+        $db = new TestLoggableDatabaseStub($c, self::databaseName, $em, 0, $loggerCallable);
         $db->setMongoDB($mdb);
 
         return $db;

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -592,12 +592,12 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
 
     private function getStubQueryBuilder()
     {
-        return new BuilderStub($this->getMockDatabase(), $this->getMockCollection(), '$');
+        return new BuilderStub($this->getMockDatabase(), $this->getMockCollection());
     }
 
     private function getTestQueryBuilder()
     {
-        return new Builder($this->getMockDatabase(), $this->getMockCollection(), '$');
+        return new Builder($this->getMockDatabase(), $this->getMockCollection());
     }
 
     private function getMockCollection()

--- a/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
@@ -8,7 +8,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 {
     public function testAddManyToSet()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->addManyToSet(array(1, 2)));
         $this->assertEquals(array('$addToSet' => array('a' => array('$each' => array(1, 2)))), $expr->getNewObj());
@@ -16,7 +16,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testAddToSetWithValue()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->addToSet(1));
         $this->assertEquals(array('$addToSet' => array('a' => 1)), $expr->getNewObj());
@@ -24,8 +24,8 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testAddToSetWithExpression()
     {
-        $expr = new Expr('$');
-        $eachExpr = new Expr('$');
+        $expr = new Expr();
+        $eachExpr = new Expr();
         $eachExpr->each(array(1, 2));
 
         $this->assertSame($expr, $expr->field('a')->addToSet($eachExpr));
@@ -34,7 +34,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testOperatorWithCurrentField()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->field('field');
 
         $this->assertSame($expr, $expr->operator('$op', 'value'));
@@ -43,7 +43,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testOperatorWithoutCurrentField()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->operator('$op', 'value'));
         $this->assertEquals(array('$op' => 'value'), $expr->getQuery());
@@ -54,7 +54,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testMaxDistanceWithNearAndGeoJsonPoint($point, array $expected)
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->near($point);
 
         $this->assertSame($expr, $expr->maxDistance(1));
@@ -74,7 +74,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testMaxDistanceWithNearAndLegacyCoordinates()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->near(1, 2);
 
         $this->assertSame($expr, $expr->maxDistance(1));
@@ -85,7 +85,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
     {
         $json = array('type' => 'Point', 'coordinates' => array(1, 2));
 
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->nearSphere($this->getMockPoint($json));
 
         $this->assertSame($expr, $expr->maxDistance(1));
@@ -94,7 +94,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testMaxDistanceWithNearSphereAndLegacyCoordinates()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->nearSphere(1, 2);
 
         $this->assertSame($expr, $expr->maxDistance(1));
@@ -106,7 +106,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testMaxDistanceRequiresNearOrNearSphereOperator()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->maxDistance(1);
     }
 
@@ -115,7 +115,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testNearWithGeoJsonPoint($point, array $expected)
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->near($point));
         $this->assertEquals(array('$near' => $expected), $expr->getQuery());
@@ -123,7 +123,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testNearWithLegacyCoordinates()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->near(1, 2));
         $this->assertEquals(array('$near' => array(1, 2)), $expr->getQuery());
@@ -134,7 +134,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testNearSphereWithGeoJsonPoint($point, array $expected)
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->nearSphere($point));
         $this->assertEquals(array('$nearSphere' => $expected), $expr->getQuery());
@@ -142,7 +142,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testNearSphereWithLegacyCoordinates()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->nearSphere(1, 2));
         $this->assertEquals(array('$nearSphere' => array(1, 2)), $expr->getQuery());
@@ -150,7 +150,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testPullWithValue()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->pull(1));
         $this->assertEquals(array('$pull' => array('a' => 1)), $expr->getNewObj());
@@ -158,8 +158,8 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testPullWithExpression()
     {
-        $expr = new Expr('$');
-        $nestedExpr = new Expr('$');
+        $expr = new Expr();
+        $nestedExpr = new Expr();
         $nestedExpr->gt(3);
 
         $this->assertSame($expr, $expr->field('a')->pull($nestedExpr));
@@ -168,7 +168,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testPushWithValue()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->push(1));
         $this->assertEquals(array('$push' => array('a' => 1)), $expr->getNewObj());
@@ -176,8 +176,8 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testPushWithExpression()
     {
-        $expr = new Expr('$');
-        $innerExpr = new Expr('$');
+        $expr = new Expr();
+        $innerExpr = new Expr();
         $innerExpr
             ->each(array(array('x' => 1), array('x' => 2)))
             ->slice(-2)
@@ -197,8 +197,8 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testPushWithExpressionShouldEnsureEachOperatorAppearsFirst()
     {
-        $expr = new Expr('$');
-        $innerExpr = new Expr('$');
+        $expr = new Expr();
+        $innerExpr = new Expr();
         $innerExpr
             ->sort('x', 1)
             ->slice(-2)
@@ -221,7 +221,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testGeoIntersects($geometry, array $expected)
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->geoIntersects($geometry));
         $this->assertEquals(array('$geoIntersects' => $expected), $expr->getQuery());
@@ -247,7 +247,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testGeoWithin($geometry, array $expected)
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->geoWithin($geometry));
         $this->assertEquals(array('$geoWithin' => $expected), $expr->getQuery());
@@ -255,7 +255,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testGeoWithinBox()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->geoWithinBox(1, 2, 3, 4));
         $this->assertEquals(array('$geoWithin' => array('$box' => array(array(1, 2), array(3, 4)))), $expr->getQuery());
@@ -263,7 +263,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testGeoWithinCenter()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->geoWithinCenter(1, 2, 3));
         $this->assertEquals(array('$geoWithin' => array('$center' => array(array(1, 2), 3))), $expr->getQuery());
@@ -271,7 +271,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testGeoWithinCenterSphere()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->geoWithinCenterSphere(1, 2, 3));
         $this->assertEquals(array('$geoWithin' => array('$centerSphere' => array(array(1, 2), 3))), $expr->getQuery());
@@ -279,7 +279,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testGeoWithinPolygon()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expectedQuery = array('$geoWithin' => array('$polygon' => array(array(0, 0), array(1, 1), array(1, 0))));
 
         $this->assertSame($expr, $expr->geoWithinPolygon(array(0, 0), array(1, 1), array(1, 0)));
@@ -291,13 +291,13 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testGeoWithinPolygonRequiresAtLeastThreePoints()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->geoWithinPolygon(array(0, 0), array(1, 1));
     }
 
     public function testSetWithAtomic()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->set(1, true));
         $this->assertEquals(array('$set' => array('a' => 1)), $expr->getNewObj());
@@ -305,7 +305,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testSetWithoutAtomicWithTopLevelField()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a')->set(1, false));
         $this->assertEquals(array('a' => 1), $expr->getNewObj());
@@ -313,7 +313,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testSetWithoutAtomicWithNestedField()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->field('a.b.c')->set(1, false));
         $this->assertEquals(array('a' => array('b' => array('c' => 1))), $expr->getNewObj());
@@ -321,7 +321,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testWhere()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->where('javascript'));
         $this->assertEquals(array('$where' => 'javascript'), $expr->getQuery());
@@ -330,7 +330,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testWithinBox()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->withinBox(1, 2, 3, 4));
         $this->assertEquals(array('$within' => array('$box' => array(array(1, 2), array(3, 4)))), $expr->getQuery());
@@ -338,7 +338,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testWithinCenter()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->withinCenter(1, 2, 3));
         $this->assertEquals(array('$within' => array('$center' => array(array(1, 2), 3))), $expr->getQuery());
@@ -346,7 +346,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testWithinCenterSphere()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
 
         $this->assertSame($expr, $expr->withinCenterSphere(1, 2, 3));
         $this->assertEquals(array('$within' => array('$centerSphere' => array(array(1, 2), 3))), $expr->getQuery());
@@ -354,7 +354,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
 
     public function testWithinPolygon()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expectedQuery = array('$within' => array('$polygon' => array(array(0, 0), array(1, 1), array(1, 0))));
 
         $this->assertSame($expr, $expr->withinPolygon(array(0, 0), array(1, 1), array(1, 0)));
@@ -366,7 +366,7 @@ class ExprTest extends \PHPUnit_Framework_TestCase
      */
     public function testWithinPolygonRequiresAtLeastThreePoints()
     {
-        $expr = new Expr('$');
+        $expr = new Expr();
         $expr->withinPolygon(array(0, 0), array(1, 1));
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -11,7 +11,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorShouldThrowExceptionForInvalidType()
     {
-        new Query($this->getMockDatabase(), $this->getMockCollection(), array('type' => -1), array(), '$');
+        new Query($this->getMockDatabase(), $this->getMockCollection(), array('type' => -1), array());
     }
 
     /**
@@ -23,7 +23,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $collection = $this->getMockCollection();
         $collection->expects($this->never())->method($method);
 
-        $query = new Query($this->getMockDatabase(), $collection, array('type' => $type), array(), '$');
+        $query = new Query($this->getMockDatabase(), $collection, array('type' => $type), array());
 
         $query->getIterator();
     }
@@ -61,7 +61,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             'distinct' => 0,
         );
 
-        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array(), '$');
+        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array());
 
         $query->getIterator();
     }
@@ -100,7 +100,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             ->method('group')
             ->with($keys, $initial, $reduce, array('finalize' => $finalize, 'cond' => array('type' => 1)));
 
-        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array(), '$');
+        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array());
         $query->execute();
     }
 
@@ -126,7 +126,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             ->method('mapReduce')
             ->with($map, $reduce, 'collection', array('type' => 1), array('limit' => 10, 'jsMode' => true));
 
-        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array(), '$');
+        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array());
         $query->execute();
     }
 
@@ -147,7 +147,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase
             ->method('near')
             ->with(array(1, 1), array('type' => 1), array('num' => 10, 'spherical' => true));
 
-        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array(), '$');
+        $query = new Query($this->getMockDatabase(), $collection, $queryArray, array());
         $query->execute();
     }
 

--- a/tests/Doctrine/MongoDB/Tests/RetryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/RetryTest.php
@@ -37,7 +37,7 @@ class RetryTest extends BaseTest
     {
         $database = $this->conn->selectDatabase('test');
         $mongoCollection = $database->selectCollection('test')->getMongoCollection();
-        $collection = new CollectionStub($this->conn, $mongoCollection, $database, $this->conn->getEventManager(), '$', 1);
+        $collection = new CollectionStub($this->conn, $mongoCollection, $database, $this->conn->getEventManager(), 1);
         $exception = new \MongoException('Test');
         try {
             $collection->testRetries($exception);


### PR DESCRIPTION
Even if the "mongo.cmd" INI option is customized, the orignal "$" character may still be used. There is no functional reason to support a customizable command character in Doctrine.
