### PR TITLE
Fix default sort order in Query Builder

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -1344,7 +1344,7 @@ class Builder
      * @param int|string $order       Field order (if one field is specified)
      * @return self
      */
-    public function sort($fieldName, $order = null)
+    public function sort($fieldName, $order = 1)
     {
         if ( ! isset($this->query['sort'])) {
             $this->query['sort'] = array();


### PR DESCRIPTION
cursor.sort() expects a value of 1 for ascending or -1 for descending. Calling Builder::sort($field) would result in a sort with a value of 0.

Resorting to a default ascending order when not having specified a sort order.
