### PR TITLE
Reset cursor before and after getSingleResult()

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -296,7 +296,10 @@ class Cursor implements Iterator
     }
 
     /**
-     * Return the cursor's first result.
+     * Reset the cursor and return its first result.
+     *
+     * The cursor will be reset both before and after the single result is
+     * fetched. The original cursor limit (if any) will remain in place.
      *
      * @see Iterator::getSingleResult()
      * @return array|object|null
@@ -304,6 +307,7 @@ class Cursor implements Iterator
     public function getSingleResult()
     {
         $originalLimit = $this->limit;
+        $this->reset();
         $this->limit(1);
         $result = current($this->toArray()) ?: null;
         $this->reset();

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -58,6 +58,15 @@ class CursorTest extends BaseTest
     /**
      * @covers Doctrine\MongoDB\Cursor::getSingleResult
      */
+    public function testCursorIsResetBeforeGetSingleResult()
+    {
+        $this->assertEquals($this->doc1, $this->cursor->getNext());
+        $this->assertEquals($this->doc1, $this->cursor->getSingleResult());
+    }
+
+    /**
+     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     */
     public function testGetSingleResultReturnsNull()
     {
         $collection = $this->conn->selectCollection(self::$dbName, 'tmp');


### PR DESCRIPTION
Fixes https://github.com/doctrine/mongodb-odm/issues/520
