### PR TITLE
Allow string or array Cursor::hint() argument

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -336,7 +336,7 @@ class Cursor implements Iterator
      * @param array|string $keyPattern
      * @return self
      */
-    public function hint(array $keyPattern)
+    public function hint($keyPattern)
     {
         $this->hint = $keyPattern;
         $this->mongoCursor->hint($keyPattern);

--- a/lib/Doctrine/MongoDB/LoggableCursor.php
+++ b/lib/Doctrine/MongoDB/LoggableCursor.php
@@ -79,7 +79,7 @@ class LoggableCursor extends Cursor implements Loggable
     /**
      * @see Cursor::hint()
      */
-    public function hint(array $keyPattern)
+    public function hint($keyPattern)
     {
         $this->log(array(
             'hint' => true,


### PR DESCRIPTION
This is a copy of https://github.com/doctrine/mongodb/pull/159, which I inadvertently applied to `1.0.x` and needed to revert.
