### PR TITLE
Fix handling of client options (e.g. socket timeout) in command helpers

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -892,6 +892,8 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
+
         $command = array();
         $command['distinct'] = $this->mongoCollection->getName();
         $command['key'] = $field;
@@ -956,6 +958,8 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
+
         $command = array();
         $command['findandmodify'] = $this->mongoCollection->getName();
         $command['query'] = (object) $query;
@@ -986,6 +990,8 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
+
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['findandmodify'] = $this->mongoCollection->getName();
@@ -1049,6 +1055,8 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
+
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['ns'] = $this->mongoCollection->getName();
@@ -1127,6 +1135,8 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
+
         $command = array();
         $command['mapreduce'] = $this->mongoCollection->getName();
         $command['map'] = $map;
@@ -1183,6 +1193,8 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
+
+        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['geoNear'] = $this->mongoCollection->getName();


### PR DESCRIPTION
This fixes code originally introduced in a3aaffa. For convenience, command helpers take a single options array. Previously, all of those options were merged into the command document, which meant that client options were never seen by the driver. Now, client options are split from the helper's single options array so they may be passed to MongoDB::command() appropriately.
