### PR TITLE
Support aggregation command cursors and client options

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -846,15 +846,18 @@ class Collection
      */
     protected function doAggregate(array $pipeline, array $options = array())
     {
-        $options = isset($options['timeout']) ? $this->convertSocketTimeout($options) : $options;
+        list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
+            ? $this->splitCommandAndClientOptions($options)
+            : array($options, array());
 
         $command = array();
         $command['aggregate'] = $this->mongoCollection->getName();
         $command['pipeline'] = $pipeline;
+        $command = array_merge($command, $commandOptions);
 
         $database = $this->database;
-        $result = $this->retry(function() use ($database, $command, $options) {
-            return $database->command($command, $options);
+        $result = $this->retry(function() use ($database, $command, $clientOptions) {
+            return $database->command($command, $clientOptions);
         });
 
         if (empty($result['ok'])) {

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -32,6 +32,7 @@ use Doctrine\MongoDB\Event\UpdateEventArgs;
 use Doctrine\MongoDB\Exception\ResultException;
 use Doctrine\MongoDB\Util\ReadPreference;
 use GeoJson\Geometry\Point;
+use BadMethodCallException;
 use MongoCommandCursor;
 
 /**
@@ -896,9 +897,14 @@ class Collection
      * @param array $pipeline
      * @param array $options
      * @return CommandCursor
+     * @throws BadMethodCallException if MongoCollection::aggregateCursor() is not available
      */
     protected function doAggregateCursor(array $pipeline, array $options = array())
     {
+        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
+            throw new BadMethodCallException('MongoCollection::aggregateCursor() is not available');
+        }
+
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -111,7 +111,7 @@ class Collection
         }
 
         if ($this->eventManager->hasListeners(Events::preAggregate)) {
-            $this->eventManager->dispatchEvent(Events::preAggregate, new AggregateEventArgs($this, $pipeline));
+            $this->eventManager->dispatchEvent(Events::preAggregate, new AggregateEventArgs($this, $pipeline, $options));
         }
 
         $result = $this->doAggregate($pipeline, $options);

--- a/lib/Doctrine/MongoDB/CommandCursor.php
+++ b/lib/Doctrine/MongoDB/CommandCursor.php
@@ -1,0 +1,271 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB;
+
+use MongoCommandCursor;
+
+/**
+ * Wrapper for the PHP MongoCommandCursor class.
+ *
+ * @since  1.2
+ * @author Jeremy Mikola <jmikola@gmail.com>
+ */
+class CommandCursor implements Iterator
+{
+    /**
+     * The MongoCommandCursor instance being wrapped.
+     *
+     * @var MongoCommandCursor
+     */
+    private $mongoCommandCursor;
+
+    /**
+     * Number of times to retry queries.
+     *
+     * @var integer
+     */
+    private $numRetries;
+
+    private $batchSize;
+    private $timeout;
+
+    /**
+     * Constructor.
+     *
+     * @param MongoCommandCursor $mongoCommandCursor MongoCommandCursor instance being wrapped
+     * @param integer            $numRetries         Number of times to retry queries
+     */
+    public function __construct(MongoCommandCursor $mongoCommandCursor, $numRetries = 0)
+    {
+        $this->mongoCommandCursor = $mongoCommandCursor;
+        $this->numRetries = (integer) $numRetries;
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::batchSize().
+     *
+     * @see http://php.net/manual/en/mongocommandcursor.batchsize.php
+     * @param integer $num
+     * @return self
+     */
+    public function batchSize($num)
+    {
+        $this->batchSize = (integer) $num;
+        $this->mongoCommandCursor->batchSize($num);
+
+        return $this;
+    }
+
+    /**
+     * Recreates the command cursor and counts its results.
+     *
+     * @see http://php.net/manual/en/countable.count.php
+     * @return integer
+     */
+    public function count()
+    {
+        $cursor = $this;
+
+        return $this->retry(function() use ($cursor) {
+            return iterator_count($cursor);
+        });
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::current().
+     *
+     * @see http://php.net/manual/en/iterator.current.php
+     * @see http://php.net/manual/en/mongocommandcursor.current.php
+     * @return array|null
+     */
+    public function current()
+    {
+        return $this->mongoCommandCursor->current();
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::dead().
+     *
+     * @see http://php.net/manual/en/mongocommandcursor.dead.php
+     * @return boolean
+     */
+    public function dead()
+    {
+        return $this->mongoCommandCursor->dead();
+    }
+
+    /**
+     * Returns the MongoCommandCursor instance being wrapped.
+     *
+     * @return \MongoCommandCursor
+     */
+    public function getMongoCommandCursor()
+    {
+        return $this->mongoCommandCursor;
+    }
+
+    /**
+     * Rewind the cursor and return its first result.
+     *
+     * @see Iterator::getSingleResult()
+     * @return array|null
+     */
+    public function getSingleResult()
+    {
+        $result = null;
+        foreach ($this as $result) {
+            break;
+        }
+        /* Avoid rewinding the cursor here, as that would re-execute the
+         * command prematurely and later iteration will rewind on its own.
+         */
+
+        return $result;
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::info().
+     *
+     * @see http://php.net/manual/en/mongocommandcursor.info.php
+     * @return array
+     */
+    public function info()
+    {
+        return $this->mongoCommandCursor->info();
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::key().
+     *
+     * @see http://php.net/manual/en/iterator.key.php
+     * @see http://php.net/manual/en/mongocommandcursor.key.php
+     * @return integer
+     */
+    public function key()
+    {
+        return $this->mongoCommandCursor->key();
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::next().
+     *
+     * @see http://php.net/manual/en/iterator.next.php
+     * @see http://php.net/manual/en/mongocommandcursor.next.php
+     */
+    public function next()
+    {
+        $cursor = $this;
+
+        $this->retry(function() use ($cursor) {
+            $cursor->getMongoCommandCursor()->next();
+        });
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::rewind().
+     *
+     * @see http://php.net/manual/en/iterator.rewind.php
+     * @see http://php.net/manual/en/mongocommandcursor.rewind.php
+     * @return array
+     */
+    public function rewind()
+    {
+        $cursor = $this;
+
+        return $this->retry(function() use ($cursor) {
+            return $cursor->getMongoCommandCursor()->rewind();
+        });
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::timeout().
+     *
+     * @see http://php.net/manual/en/mongocommandcursor.timeout.php
+     * @param integer $ms
+     * @return self
+     */
+    public function timeout($ms)
+    {
+        $this->timeout = (integer) $ms;
+        $this->mongoCommandCursor->timeout($ms);
+
+        return $this;
+    }
+
+    /**
+     * Return the cursor's results as an array.
+     *
+     * @see Iterator::toArray()
+     * @return array
+     */
+    public function toArray()
+    {
+        $cursor = $this;
+
+        return $this->retry(function() use ($cursor) {
+            return iterator_to_array($cursor);
+        });
+    }
+
+    /**
+     * Wrapper method for MongoCommandCursor::valid().
+     *
+     * @see http://php.net/manual/en/iterator.valid.php
+     * @see http://php.net/manual/en/mongocommandcursor.valid.php
+     * @return boolean
+     */
+    public function valid()
+    {
+        return $this->mongoCommandCursor->valid();
+    }
+
+    /**
+     * Conditionally retry a closure if it yields an exception.
+     *
+     * If the closure does not return successfully within the configured number
+     * of retries, its first exception will be thrown.
+     *
+     * @param \Closure $retry
+     * @return mixed
+     */
+    protected function retry(\Closure $retry)
+    {
+        if ($this->numRetries < 1) {
+            return $retry();
+        }
+
+        $firstException = null;
+
+        for ($i = 0; $i <= $this->numRetries; $i++) {
+            try {
+                return $retry();
+            } catch (\MongoCursorException $e) {
+            } catch (\MongoConnectionException $e) {
+            }
+
+            if ($firstException === null) {
+                $firstException = $e;
+            }
+            if ($i === $this->numRetries) {
+                throw $firstException;
+            }
+        }
+    }
+}

--- a/lib/Doctrine/MongoDB/CommandCursor.php
+++ b/lib/Doctrine/MongoDB/CommandCursor.php
@@ -19,6 +19,7 @@
 
 namespace Doctrine\MongoDB;
 
+use BadMethodCallException;
 use MongoCommandCursor;
 
 /**
@@ -200,9 +201,14 @@ class CommandCursor implements Iterator
      * @see http://php.net/manual/en/mongocommandcursor.timeout.php
      * @param integer $ms
      * @return self
+     * @throws BadMethodCallException if MongoCommandCursor::timeout() is not available
      */
     public function timeout($ms)
     {
+        if ( ! method_exists('MongoCommandCursor', 'timeout')) {
+            throw new BadMethodCallException('MongoCommandCursor::timeout() is not available');
+        }
+
         $this->timeout = (integer) $ms;
         $this->mongoCommandCursor->timeout($ms);
 

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -97,15 +97,21 @@ class Database
      * Wrapper method for MongoDB::command().
      *
      * @see http://php.net/manual/en/mongodb.command.php
-     * @param array $data
-     * @param array $options
+     * @param array  $command Command document
+     * @param array  $options Client-side options (e.g. socket timeout)
+     * @param string $hash    Optional reference argument to collect the server
+     *                        hash for command cursors (for driver 1.5+ only)
      * @return array
      */
-    public function command(array $data, array $options = array())
+    public function command(array $command, array $options = array(), &$hash = null)
     {
         $options = isset($options['timeout']) ? $this->convertSocketTimeout($options) : $options;
 
-        return $this->mongoDB->command($data, $options);
+        if (func_num_args() > 2) {
+            return $this->mongoDB->command($command, $options, $hash);
+        }
+
+        return $this->mongoDB->command($command, $options);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Event/AggregateEventArgs.php
+++ b/lib/Doctrine/MongoDB/Event/AggregateEventArgs.php
@@ -31,6 +31,7 @@ class AggregateEventArgs extends BaseEventArgs
 {
     private $invoker;
     private $pipeline;
+    private $options;
 
     /**
      * Constructor.
@@ -38,10 +39,11 @@ class AggregateEventArgs extends BaseEventArgs
      * @param object $invoker
      * @param array  $pipeline
      */
-    public function __construct($invoker, array $pipeline)
+    public function __construct($invoker, array $pipeline, array $options = array())
     {
         $this->invoker = $invoker;
         $this->pipeline = $pipeline;
+        $this->options = $options;
     }
 
     public function getInvoker()
@@ -52,5 +54,13 @@ class AggregateEventArgs extends BaseEventArgs
     public function getPipeline()
     {
         return $this->pipeline;
+    }
+
+    /**
+     * @since 1.2
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }

--- a/lib/Doctrine/MongoDB/LoggableCollection.php
+++ b/lib/Doctrine/MongoDB/LoggableCollection.php
@@ -69,6 +69,25 @@ class LoggableCollection extends Collection implements Loggable
     }
 
     /**
+     * @see Collection::aggregate()
+     */
+    public function aggregate(array $pipeline, array $options = array() /* , array $op, ... */)
+    {
+        if ( ! array_key_exists(0, $pipeline)) {
+            $pipeline = func_get_args();
+            $options = array();
+        }
+
+        $this->log(array(
+            'aggregate' => true,
+            'pipeline' => $pipeline,
+            'options' => $options,
+        ));
+
+        return parent::aggregate($pipeline, $options);
+    }
+
+    /**
      * @see Collection::batchInsert()
      */
     public function batchInsert(array &$a, array $options = array())
@@ -98,6 +117,10 @@ class LoggableCollection extends Collection implements Loggable
         return parent::count($query, $limit, $skip);
     }
 
+    /* Collection::createDBRef() is intentionally omitted because it does not
+     * interact with the server.
+     */
+
     /**
      * @see Collection::deleteIndex()
      */
@@ -119,6 +142,21 @@ class LoggableCollection extends Collection implements Loggable
         $this->log(array('deleteIndexes' => true));
 
         return parent::deleteIndexes();
+    }
+
+    /**
+     * @see Collection::distinct()
+     */
+    public function distinct($field, array $query = array(), array $options = array())
+    {
+        $this->log(array(
+            'distinct' => true,
+            'field' => $field,
+            'query' => $query,
+            'options' => $options,
+        ));
+
+        return parent::distinct($field, $query, $options);
     }
 
     /**
@@ -160,6 +198,35 @@ class LoggableCollection extends Collection implements Loggable
     }
 
     /**
+     * @see Collection::findAndRemove()
+     */
+    public function findAndRemove(array $query, array $options = array())
+    {
+        $this->log(array(
+            'findAndRemove' => true,
+            'query' => $query,
+            'options' => $options,
+        ));
+
+        return parent::findAndRemove($query, $options);
+    }
+
+    /**
+     * @see Collection::findAndUpdate()
+     */
+    public function findAndUpdate(array $query, array $newObj, array $options = array())
+    {
+        $this->log(array(
+            'findAndUpdate' => true,
+            'query' => $query,
+            'newObj' => $newObj,
+            'options' => $options,
+        ));
+
+        return parent::findAndUpdate($query, $newObj, $options);
+    }
+
+    /**
      * @see Collection::findOne()
      */
     public function findOne(array $query = array(), array $fields = array())
@@ -184,6 +251,16 @@ class LoggableCollection extends Collection implements Loggable
         ));
 
         return parent::getDBRef($reference);
+    }
+
+    /**
+     * @see Collection::getIndexInfo()
+     */
+    public function getIndexInfo()
+    {
+        $this->log(array('getIndexInfo' => true));
+
+        return parent::getIndexInfo();
     }
 
     /**
@@ -214,6 +291,38 @@ class LoggableCollection extends Collection implements Loggable
         ));
 
         return parent::insert($a, $options);
+    }
+
+    /**
+     * @see Collection::mapReduce()
+     */
+    public function mapReduce($map, $reduce, $out = array('inline' => true), array $query = array(), array $options = array())
+    {
+        $this->log(array(
+            'mapReduce' => true,
+            'map' => $map,
+            'reduce' => $reduce,
+            'out' => $out,
+            'query' => $query,
+            'options' => $options,
+        ));
+
+        return parent::mapReduce($map, $reduce, $out, $query, $options);
+    }
+
+    /**
+     * @see Collection::near()
+     */
+    public function near($near, array $query = array(), array $options = array())
+    {
+        $this->log(array(
+            'geoNear' => true,
+            'near' => $near,
+            'query' => $query,
+            'options' => $options,
+        ));
+
+        return parent::near($near, $query, $options);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/LoggableDatabase.php
+++ b/lib/Doctrine/MongoDB/LoggableDatabase.php
@@ -84,13 +84,17 @@ class LoggableDatabase extends Database implements Loggable
     /**
      * @see Database::command()
      */
-    public function command(array $data, array $options = array())
+    public function command(array $data, array $options = array(), &$hash = null)
     {
         $this->log(array(
             'command' => true,
             'data' => $data,
             'options' => $options,
         ));
+
+        if (func_num_args() > 2) {
+            return parent::command($data, $options, $hash);
+        }
 
         return parent::command($data, $options);
     }

--- a/tests/Doctrine/MongoDB/Tests/BaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/BaseTest.php
@@ -29,4 +29,11 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
         $this->conn->close();
         unset($this->conn);
     }
+
+    protected function getServerVersion()
+    {
+        $result = $this->conn->selectDatabase(self::$dbName)->command(array('buildInfo' => 1));
+
+        return $result['version'];
+    }
 }

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -178,6 +178,19 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testAggregateWithCursorOptionShouldThrowExceptionForOldDrivers()
+    {
+        if (method_exists('MongoCollection', 'aggregateCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers with MongoCollection::aggregateCursor()');
+        }
+
+        $coll = $this->getTestCollection();
+        $coll->aggregate(array(array('$limit' => 1)), array('cursor' => true));
+    }
+
+    /**
      * @expectedException \Doctrine\MongoDB\Exception\ResultException
      */
     public function testAggregateShouldThrowExceptionOnError()

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -60,6 +60,111 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($arrayIterator, $result);
     }
 
+    public function testAggregateShouldReturnCursorForPipelineEndingWithOut()
+    {
+        $pipeline = array(
+            array('$match' => array('x' => '1')),
+            array('$out' => 'foo'),
+        );
+        $commandResult = array('ok' => 1);
+
+        $database = $this->getMockDatabase();
+        $database->expects($this->once())
+            ->method('command')
+            ->with(array('aggregate' => self::collectionName, 'pipeline' => $pipeline))
+            ->will($this->returnValue($commandResult));
+
+        $collection = $this->getMockCollection();
+        $database->expects($this->once())
+            ->method('selectCollection')
+            ->with('foo')
+            ->will($this->returnValue($collection));
+
+        $cursor = $this->getMockCursor();
+        $collection->expects($this->once())
+            ->method('find')
+            ->will($this->returnValue($cursor));
+
+        $coll = $this->getTestCollection($database);
+        $result = $coll->aggregate($pipeline);
+
+        $this->assertSame($cursor, $result);
+    }
+
+    public function testAggregateWithCursorOption()
+    {
+        $pipeline = array(
+            array('$match' => array('_id' => 'bar')),
+            array('$project' => array('_id' => 1)),
+        );
+        $options = array('cursor' => true);
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCollection = $this->getMockMongoCollection();
+        $mongoCollection->expects($this->once())
+            ->method('aggregateCursor')
+            ->with($pipeline, array())
+            ->will($this->returnValue($mongoCommandCursor));
+
+        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
+        $result = $coll->aggregate($pipeline, $options);
+
+        $this->assertInstanceOf('Doctrine\MongoDB\CommandCursor', $result);
+        $this->assertSame($mongoCommandCursor, $result->getMongoCommandCursor());
+    }
+
+    public function testAggregateWithCursorOptionAndBatchSize()
+    {
+        $pipeline = array(
+            array('$match' => array('_id' => 'bar')),
+            array('$project' => array('_id' => 1)),
+        );
+        $options = array('cursor' => array('batchSize' => 10));
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCollection = $this->getMockMongoCollection();
+        $mongoCollection->expects($this->once())
+            ->method('aggregateCursor')
+            ->with($pipeline, $options)
+            ->will($this->returnValue($mongoCommandCursor));
+
+        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
+        $result = $coll->aggregate($pipeline, $options);
+
+        $this->assertInstanceOf('Doctrine\MongoDB\CommandCursor', $result);
+        $this->assertSame($mongoCommandCursor, $result->getMongoCommandCursor());
+    }
+
+    public function testAggregateWithCursorOptionAndTimeout()
+    {
+        if (version_compare(phpversion('mongo'), '1.6.0', '<')) {
+            $this->markTestSkipped('This test is not applicable to driver versions < 1.6.0');
+        }
+
+        $pipeline = array(
+            array('$match' => array('_id' => 'bar')),
+            array('$project' => array('_id' => 1)),
+        );
+        $options = array('cursor' => true, 'socketTimeoutMS' => 1000);
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCollection = $this->getMockMongoCollection();
+        $mongoCollection->expects($this->once())
+            ->method('aggregateCursor')
+            ->with($pipeline, array())
+            ->will($this->returnValue($mongoCommandCursor));
+
+        $mongoCommandCursor->expects($this->once())
+            ->method('timeout')
+            ->with(1000);
+
+        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
+        $result = $coll->aggregate($pipeline, $options);
+
+        $this->assertInstanceOf('Doctrine\MongoDB\CommandCursor', $result);
+        $this->assertSame($mongoCommandCursor, $result->getMongoCommandCursor());
+    }
+
     /**
      * @expectedException \Doctrine\MongoDB\Exception\ResultException
      */
@@ -996,6 +1101,13 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(self::collectionName));
 
         return $mc;
+    }
+
+    private function getMockMongoCommandCursor()
+    {
+        return $this->getMockBuilder('MongoCommandCursor')
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     private function getMockMongoCursor()

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -93,6 +93,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOption()
     {
+        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
+        }
+
         $pipeline = array(
             array('$match' => array('_id' => 'bar')),
             array('$project' => array('_id' => 1)),
@@ -115,6 +119,10 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOptionAndBatchSize()
     {
+        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
+        }
+
         $pipeline = array(
             array('$match' => array('_id' => 'bar')),
             array('$project' => array('_id' => 1)),
@@ -137,8 +145,12 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOptionAndTimeout()
     {
-        if (version_compare(phpversion('mongo'), '1.6.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.6.0');
+        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
+        }
+
+        if ( ! method_exists('MongoCommandCursor', 'timeout')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCommandCursor::timeout()');
         }
 
         $pipeline = array(

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
@@ -11,6 +11,14 @@ class CommandCursorFunctionalTest extends BaseTest
     {
         parent::setUp();
 
+        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
+        }
+
+        if (version_compare($this->getServerVersion(), '2.6.0', '<')) {
+            $this->markTestSkipped('This test is not applicable to server versions < 2.6.0');
+        }
+
         $this->docs = array(
             array('_id' => 1),
             array('_id' => 2),

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests;
+
+class CommandCursorFunctionalTest extends BaseTest
+{
+    private $collection;
+    private $docs;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->docs = array(
+            array('_id' => 1),
+            array('_id' => 2),
+            array('_id' => 3),
+        );
+
+        $this->collection = $this->conn->selectCollection(self::$dbName, 'CommandCursorFunctionalTest');
+        $this->collection->drop();
+
+        foreach ($this->docs as $doc) {
+            $this->collection->insert($doc);
+        }
+    }
+
+    public function testCount()
+    {
+        $commandCursor = $this->collection->aggregate(
+            array(array('$sort' => array('_id' => 1))),
+            array('cursor' => true)
+        );
+
+        $this->assertCount(3, $commandCursor);
+    }
+
+    public function testGetSingleResult()
+    {
+        $commandCursor = $this->collection->aggregate(
+            array(array('$sort' => array('_id' => 1))),
+            array('cursor' => true)
+        );
+
+        $this->assertEquals($this->docs[0], $commandCursor->getSingleResult());
+    }
+
+    public function testGetSingleResultRewindsBeforeReturningFirstResult()
+    {
+        $commandCursor = $this->collection->aggregate(
+            array(array('$sort' => array('_id' => 1))),
+            array('cursor' => true)
+        );
+
+        $commandCursor->rewind();
+        $commandCursor->next();
+        $this->assertTrue($commandCursor->valid());
+        $this->assertEquals($this->docs[1], $commandCursor->current());
+        $this->assertEquals($this->docs[0], $commandCursor->getSingleResult());
+    }
+
+    /**
+     * @covers Doctrine\MongoDB\Cursor::getSingleResult
+     */
+    public function testGetSingleResultReturnsNullForEmptyResultSet()
+    {
+        $commandCursor = $this->collection->aggregate(
+            array(array('$match' => array('_id' => 0))),
+            array('cursor' => true)
+        );
+
+        $this->assertNull($commandCursor->getSingleResult());
+    }
+
+    public function testToArray()
+    {
+        $commandCursor = $this->collection->aggregate(
+            array(array('$sort' => array('_id' => 1))),
+            array('cursor' => true)
+        );
+
+        $this->assertEquals($this->docs, $commandCursor->toArray());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
@@ -6,6 +6,13 @@ use Doctrine\MongoDB\CommandCursor;
 
 class CommandCursorTest extends \PHPUnit_Framework_TestCase
 {
+    public function setUp()
+    {
+        if ( ! class_exists('MongoCommandCursor')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCommandCursor');
+        }
+    }
+
     public function testBatchSize()
     {
         $mongoCommandCursor = $this->getMockMongoCommandCursor();
@@ -51,8 +58,8 @@ class CommandCursorTest extends \PHPUnit_Framework_TestCase
 
     public function testTimeout()
     {
-        if (version_compare(phpversion('mongo'), '1.6.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.6.0');
+        if ( ! method_exists('MongoCommandCursor', 'timeout')) {
+            $this->markTestSkipped('This test is not applicable to drivers without MongoCommandCursor::timeout()');
         }
 
         $mongoCommandCursor = $this->getMockMongoCommandCursor();

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
@@ -72,6 +72,19 @@ class CommandCursorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($commandCursor, $commandCursor->timeout(1000));
     }
 
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testTimeoutShouldThrowExceptionForOldDrivers()
+    {
+        if (method_exists('MongoCommandCursor', 'timeout')) {
+            $this->markTestSkipped('This test is not applicable to drivers with MongoCommandCursor::timeout()');
+        }
+
+        $commandCursor = new CommandCursor($this->getMockMongoCommandCursor());
+        $commandCursor->timeout(1000);
+    }
+
     private function getMockMongoCommandCursor()
     {
         return $this->getMockBuilder('MongoCommandCursor')

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests;
+
+use Doctrine\MongoDB\CommandCursor;
+
+class CommandCursorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBatchSize()
+    {
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCommandCursor->expects($this->once())
+            ->method('batchSize')
+            ->with(10);
+
+        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $this->assertSame($commandCursor, $commandCursor->batchSize(10));
+    }
+
+    public function testDead()
+    {
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCommandCursor->expects($this->once())
+            ->method('dead')
+            ->will($this->returnValue(true));
+
+        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $this->assertTrue($commandCursor->dead());
+    }
+
+    public function testGetMongoCommandCursor()
+    {
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $this->assertSame($mongoCommandCursor, $commandCursor->getMongoCommandCursor());
+    }
+
+    public function testInfo()
+    {
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCommandCursor->expects($this->once())
+            ->method('info')
+            ->will($this->returnValue(array('info')));
+
+        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $this->assertEquals(array('info'), $commandCursor->info());
+    }
+
+    public function testTimeout()
+    {
+        if (version_compare(phpversion('mongo'), '1.6.0', '<')) {
+            $this->markTestSkipped('This test is not applicable to driver versions < 1.6.0');
+        }
+
+        $mongoCommandCursor = $this->getMockMongoCommandCursor();
+
+        $mongoCommandCursor->expects($this->once())
+            ->method('timeout')
+            ->with(1000);
+
+        $commandCursor = new CommandCursor($mongoCommandCursor);
+        $this->assertSame($commandCursor, $commandCursor->timeout(1000));
+    }
+
+    private function getMockMongoCommandCursor()
+    {
+        return $this->getMockBuilder('MongoCommandCursor')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -10,6 +10,21 @@ use Doctrine\Common\EventManager;
 
 class DatabaseTest extends \PHPUnit_Framework_TestCase
 {
+    public function testCommandPassesServerHashOnlyIfProvided()
+    {
+        $mongoDB = $this->getMockMongoDB();
+
+        $mongoDB->expects($this->any())
+            ->method('command')
+            ->will($this->returnArgument(2));
+
+        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
+
+        $hash = true;
+        $this->assertTrue($database->command(array('count' => 'foo'), array(), $hash));
+        $this->assertNull($database->command(array('count' => 'foo'), array()));
+    }
+
     public function testCreateCollectionWithMultipleArguments()
     {
         $mongoDB = $this->getMockMongoDB();


### PR DESCRIPTION
Supersedes #187. Fixes #189.

With driver 1.5.x, we cannot support both cursor resetting *and* socket timeouts. Cursor resetting (via `rewind()`) is necessary for the command cursor wrapper to properly implement Countable, which Doctrine's Iterator extends. Using the `createFromDocument()` factory method means we can't rewind/reset the cursor. Ultimately, this PR uses `MongoCollection::aggregateCursor()` and favors the ability to rewind the cursor over supporting a socket timeout on 1.5.x.

Related tasks:

 * [x] Implement `MongoCommandCursor::timeout()` in driver 1.6.0 ([PHP-1256](https://jira.mongodb.org/browse/PHP-1256))
 * [x] Ensure MongoCommandCursor can be rewound for `count()` and `getSingleResult()`
 * [x] Throw exception if user attempts to use aggregation cursor on driver < 1.5.0
 * [x] Throw exception if user attempts to use socket timeout on driver < 1.6.0