### PR TITLE
Remove "timeout" conversion from Collection command wrappers

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -892,8 +892,6 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
-
         $command = array();
         $command['distinct'] = $this->mongoCollection->getName();
         $command['key'] = $field;
@@ -958,8 +956,6 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
-
         $command = array();
         $command['findandmodify'] = $this->mongoCollection->getName();
         $command['query'] = (object) $query;
@@ -990,8 +986,6 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
-
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['findandmodify'] = $this->mongoCollection->getName();
@@ -1055,8 +1049,6 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
-
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['ns'] = $this->mongoCollection->getName();
@@ -1135,8 +1127,6 @@ class Collection
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
 
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
-
         $command = array();
         $command['mapreduce'] = $this->mongoCollection->getName();
         $command['map'] = $map;
@@ -1193,8 +1183,6 @@ class Collection
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());
-
-        $clientOptions = isset($clientOptions['timeout']) ? $this->convertSocketTimeout($clientOptions) : $clientOptions;
 
         $command = array();
         $command['geoNear'] = $this->mongoCollection->getName();

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -934,56 +934,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $coll->distinct('foo', array(), array('maxTimeMS' => 1000, 'socketTimeoutMS' => 2000));
     }
 
-    public function testSplitSocketTimeoutOptionIsConverted()
-    {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
-        $expectedCommand = array(
-            'distinct' => self::collectionName,
-            'key' => 'foo',
-            'query' => new \stdClass(),
-            'maxTimeMS' => 1000,
-        );
-
-        $expectedClientOptions = array('socketTimeoutMS' => 2000);
-
-        $database = $this->getMockDatabase();
-        $database->expects($this->once())
-            ->method('command')
-            ->with($expectedCommand, $expectedClientOptions)
-            ->will($this->returnValue(array('ok' => 1)));
-
-        $coll = $this->getTestCollection($database);
-        $coll->distinct('foo', array(), array('maxTimeMS' => 1000, 'timeout' => 2000));
-    }
-
-    public function testSplitSocketTimeoutOptionIsNotConvertedForOlderDrivers()
-    {
-        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.5.0');
-        }
-
-        $expectedCommand = array(
-            'distinct' => self::collectionName,
-            'key' => 'foo',
-            'query' => new \stdClass(),
-            'maxTimeMS' => 1000,
-        );
-
-        $expectedClientOptions = array('timeout' => 2000);
-
-        $database = $this->getMockDatabase();
-        $database->expects($this->once())
-            ->method('command')
-            ->with($expectedCommand, $expectedClientOptions)
-            ->will($this->returnValue(array('ok' => 1)));
-
-        $coll = $this->getTestCollection($database);
-        $coll->distinct('foo', array(), array('maxTimeMS' => 1000, 'timeout' => 2000));
-    }
-
     private function getMockCollection()
     {
         return $this->getMockBuilder('Doctrine\MongoDB\Collection')


### PR DESCRIPTION
This was originally added in #196 when fixing handling of command and client options for Collection command wrappers; however, #198 moved conversion of "timeout" to Database::command(), so we no longer need to do it in each Collection command wrapper.
