### PR TITLE
Fix issue when an operator follows equals()

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -713,6 +713,10 @@ class Expr
     public function operator($operator, $value)
     {
         if ($this->currentField) {
+            if (isset($this->query[$this->currentField]) && !is_array($this->query[$this->currentField])) {
+                $this->query[$this->currentField] = array();
+            }
+
             $this->query[$this->currentField][$operator] = $value;
         } else {
             $this->query[$operator] = $value;

--- a/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
@@ -504,4 +504,13 @@ class ExprTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expr, $expr->notIn(array(1 => 'value1', 'some' => 'value2')));
         $this->assertEquals(array('$nin' => array('value1', 'value2')), $expr->getQuery());
     }
+
+    public function testOperatorFollowsEquals()
+    {
+        $expr = new Expr();
+        $this->assertSame($expr, $expr->field('a')->equals('b'));
+        $this->assertEquals(array('a' => 'b'), $expr->getQuery());
+        $this->assertSame($expr, $expr->field('a')->in(array(1 => 'value1', 'some' => 'value2')));
+        $this->assertEquals(array('a' => array('$in' => array('value1', 'value2'))), $expr->getQuery());
+    }
 }


### PR DESCRIPTION
This fixes #181 by overwriting the existing query with an empty array to avoid invalid string offsets or invalid array accesses when calling any query operator after having called ```equals()``` on the field.