### PR TITLE
Don't pass empty arrays to array_combine()

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -432,6 +432,10 @@ class Query implements IteratorAggregate
      */
     private function renameQueryOptions(array $options, array $rename)
     {
+        if (empty($options)) {
+            return $options;
+        }
+
         return array_combine(
             array_map(
                 function($key) use ($rename) { return isset($rename[$key]) ? $rename[$key] : $key; },


### PR DESCRIPTION
Fixes #204 for PHP 5.3.