### PR TITLE
Add a common cursor interface

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -27,7 +27,7 @@ use Doctrine\MongoDB\Util\ReadPreference;
  * @since  1.0
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
-class Cursor implements Iterator
+class Cursor implements CursorInterface
 {
     /**
      * The Collection instance used for recreating this cursor.

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -53,7 +53,6 @@ interface CursorInterface extends Iterator
      *
      * @see http://php.net/manual/en/countable.count.php
      * @see http://php.net/manual/en/mongocursor.count.php
-     * @param boolean $foundOnly
      * @return integer
      */
     public function count();

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB;
+
+use Doctrine\MongoDB\Util\ReadPreference;
+
+/**
+ * Wrapper for the PHP MongoCursor class.
+ *
+ * @since  1.0
+ * @author alcaeus <alcaeus@alcaeus.org>
+ */
+interface CursorInterface extends Iterator
+{
+    /**
+     * Wrapper method for MongoCursor::addOption().
+     *
+     * @see http://php.net/manual/en/mongocursor.addoption.php
+     * @param string $key
+     * @param mixed $value
+     * @return self
+     */
+    public function addOption($key, $value);
+
+    /**
+     * Wrapper method for MongoCursor::batchSize().
+     *
+     * @see http://php.net/manual/en/mongocursor.batchsize.php
+     * @param integer $num
+     * @return self
+     */
+    public function batchSize($num);
+
+    /**
+     * Wrapper method for MongoCursor::count().
+     *
+     * @see http://php.net/manual/en/countable.count.php
+     * @see http://php.net/manual/en/mongocursor.count.php
+     * @param boolean $foundOnly
+     * @return integer
+     */
+    public function count();
+
+    /**
+     * Wrapper method for MongoCursor::dead().
+     *
+     * @see http://php.net/manual/en/mongocursor.dead.php
+     * @return boolean
+     */
+    public function dead();
+
+    /**
+     * Wrapper method for MongoCursor::explain().
+     *
+     * @see http://php.net/manual/en/mongocursor.explain.php
+     * @return array
+     */
+    public function explain();
+
+    /**
+     * Wrapper method for MongoCursor::fields().
+     *
+     * @see http://php.net/manual/en/mongocursor.fields.php
+     * @return self
+     */
+    public function fields(array $f);
+
+    /**
+     * Wrapper method for MongoCursor::getReadPreference().
+     *
+     * @see http://php.net/manual/en/mongocursor.getreadpreference.php
+     * @return array
+     */
+    public function getReadPreference();
+
+    /**
+     * Set the read preference.
+     *
+     * @see http://php.net/manual/en/mongocursor.setreadpreference.php
+     * @param string $readPreference
+     * @param array  $tags
+     * @return self
+     */
+    public function setReadPreference($readPreference, array $tags = null);
+
+    /**
+     * Wrapper method for MongoCursor::hint().
+     *
+     * @see http://php.net/manual/en/mongocursor.hint.php
+     * @param array|string $keyPattern
+     * @return self
+     */
+    public function hint($keyPattern);
+
+    /**
+     * Wrapper method for MongoCursor::immortal().
+     *
+     * @see http://php.net/manual/en/mongocursor.immortal.php
+     * @param boolean $liveForever
+     * @return self
+     */
+    public function immortal($liveForever = true);
+
+    /**
+     * Wrapper method for MongoCursor::info().
+     *
+     * @see http://php.net/manual/en/mongocursor.info.php
+     * @return array
+     */
+    public function info();
+
+    /**
+     * Wrapper method for MongoCursor::limit().
+     *
+     * @see http://php.net/manual/en/mongocursor.limit.php
+     * @param integer $num
+     * @return self
+     */
+    public function limit($num);
+
+    /**
+     * Wrapper method for MongoCursor::reset().
+     *
+     * @see http://php.net/manual/en/iterator.reset.php
+     * @see http://php.net/manual/en/mongocursor.reset.php
+     */
+    public function reset();
+
+    /**
+     * Wrapper method for MongoCursor::skip().
+     *
+     * @see http://php.net/manual/en/mongocursor.skip.php
+     * @param integer $num
+     * @return self
+     */
+    public function skip($num);
+
+    /**
+     * Wrapper method for MongoCursor::slaveOkay().
+     *
+     * @see http://php.net/manual/en/mongocursor.slaveokay.php
+     * @param boolean $ok
+     * @return self
+     */
+    public function slaveOkay($ok = true);
+
+    /**
+     * Wrapper method for MongoCursor::snapshot().
+     *
+     * @see http://php.net/manual/en/mongocursor.snapshot.php
+     * @return self
+     */
+    public function snapshot();
+
+    /**
+     * Wrapper method for MongoCursor::sort().
+     *
+     * @see http://php.net/manual/en/mongocursor.sort.php
+     * @param array $fields
+     * @return self
+     */
+    public function sort($fields);
+
+    /**
+     * Wrapper method for MongoCursor::tailable().
+     *
+     * @see http://php.net/manual/en/mongocursor.tailable.php
+     * @param boolean $tail
+     * @return self
+     */
+    public function tailable($tail = true);
+
+    /**
+     * Wrapper method for MongoCursor::timeout().
+     *
+     * @see http://php.net/manual/en/mongocursor.timeout.php
+     * @param integer $ms
+     * @return self
+     */
+    public function timeout($ms);
+}

--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -26,7 +26,7 @@ namespace Doctrine\MongoDB;
  * @since  1.0
  * @author Jonathan H. Wage <jonwage@gmail.com>
  */
-class EagerCursor implements Iterator
+class EagerCursor implements CursorInterface
 {
     /**
      * The Cursor instance being wrapped.
@@ -65,6 +65,7 @@ class EagerCursor implements Iterator
     public function count()
     {
         $this->initialize();
+
         return count($this->data);
     }
 
@@ -74,6 +75,7 @@ class EagerCursor implements Iterator
     public function current()
     {
         $this->initialize();
+
         return current($this->data);
     }
 
@@ -128,6 +130,7 @@ class EagerCursor implements Iterator
     public function key()
     {
         $this->initialize();
+
         return key($this->data);
     }
 
@@ -155,6 +158,7 @@ class EagerCursor implements Iterator
     public function toArray()
     {
         $this->initialize();
+
         return $this->data;
     }
 
@@ -164,6 +168,177 @@ class EagerCursor implements Iterator
     public function valid()
     {
         $this->initialize();
+
         return key($this->data) !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addOption($key, $value)
+    {
+        $this->cursor->addOption($key, $value);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function batchSize($num)
+    {
+        $this->cursor->batchSize($num);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dead()
+    {
+        return $this->cursor->dead();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function explain()
+    {
+        return $this->cursor->explain();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fields(array $f)
+    {
+        $this->cursor->fields($f);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReadPreference()
+    {
+        return $this->cursor->getReadPreference();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setReadPreference($readPreference, array $tags = null)
+    {
+        $this->cursor->setReadPreference($readPreference, $tags);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hint($keyPattern)
+    {
+        $this->cursor->hint($keyPattern);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function immortal($liveForever = true)
+    {
+        $this->cursor->immortal($liveForever);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info()
+    {
+        return $this->cursor->info();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function limit($num)
+    {
+        $this->cursor->limit($num);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->cursor->reset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function skip($num)
+    {
+        $this->cursor->limit($num);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function slaveOkay($ok = true)
+    {
+        $this->cursor->slaveOkay($ok);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function snapshot()
+    {
+        $this->cursor->snapshot();
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sort($fields)
+    {
+        $this->cursor->sort($fields);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tailable($tail = true)
+    {
+        $this->cursor->tailable($tail);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function timeout($ms)
+    {
+        $this->cursor->timeout($ms);
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR aims to fix #208 by adding a common ```CursorInterface``` which contains most methods from ```MongoCursor``` and aims to have ```Cursor``` and ```EagerCursor``` provide the same functionality. Note that ```EagerCursor``` will delegate all calls to the wrapped ```Cursor``` instance. It's up to the user to ensure the underlying cursor object has not been opened by calling ```current``` or ```next```.