### PR TITLE
Query builder support for new update operators in MongoDB 2.6

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -915,6 +915,20 @@ class Builder
     }
 
     /**
+     * Updates the value of the field to a specified value if the specified value is greater than the current value of the field.
+     *
+     * @see Expr::max()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+     * @param mixed $value
+     * @return self
+     */
+    public function max($value)
+    {
+        $this->expr->max($value);
+        return $this;
+    }
+
+    /**
      * Set the "maxDistance" option for a geoNear command query or add
      * $maxDistance criteria to the query.
      *
@@ -941,6 +955,20 @@ class Builder
         } else {
             $this->expr->maxDistance($maxDistance);
         }
+        return $this;
+    }
+
+    /**
+     * Updates the value of the field to a specified value if the specified value is less than the current value of the field.
+     *
+     * @see Expr::min()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+     * @param mixed $value
+     * @return self
+     */
+    public function min($value)
+    {
+        $this->expr->min($value);
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -186,6 +186,20 @@ class Builder
     }
 
     /**
+     * Sets the value of the current field to the current date, either as a date or a timestamp.
+     *
+     * @see Expr::currentDate()
+     * @see http://docs.mongodb.org/manual/reference/operator/currentDate/
+     * @param bool $useTimestamp
+     * @return self
+     */
+    public function currentDate($useTimestamp = false)
+    {
+        $this->expr->currentDate($useTimestamp);
+        return $this;
+    }
+
+    /**
      * Return an array of information about the Builder state for debugging.
      *
      * The $name parameter may be used to return a specific key from the

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -934,6 +934,22 @@ class Builder
     }
 
     /**
+     * Multiply the current field.
+     *
+     * If the field does not exist, it will be set to 0.
+     *
+     * @see Expr::mul()
+     * @see http://docs.mongodb.org/manual/reference/operator/mul/
+     * @param float|integer $value
+     * @return self
+     */
+    public function mul($value)
+    {
+        $this->expr->mul($value);
+        return $this;
+    }
+
+    /**
      * Set the "multiple" option for an update query.
      *
      * @param boolean $bool

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -175,6 +175,48 @@ class Builder
     }
 
     /**
+     * Apply a bitwise and operation on the current field.
+     *
+     * @see Expr::bitAnd()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitAnd($value)
+    {
+        $this->expr->bitAnd($value);
+        return $this;
+    }
+
+    /**
+     * Apply a bitwise or operation on the current field.
+     *
+     * @see Expr::bitOr()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitOr($value)
+    {
+        $this->expr->bitOr($value);
+        return $this;
+    }
+
+    /**
+     * Apply a bitwise xor operation on the current field.
+     *
+     * @see Expr::bitXor()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitXor($value)
+    {
+        $this->expr->bitXor($value);
+        return $this;
+    }
+
+    /**
      * Change the query type to count.
      *
      * @return self

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -591,6 +591,21 @@ class Expr
     }
 
     /**
+     * Updates the value of the field to a specified value if the specified value is greater than the current value of the field.
+     *
+     * @see Builder::max()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/max/
+     * @param mixed $value
+     * @return self
+     */
+    public function max($value)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$max'][$this->currentField] = $value;
+        return $this;
+    }
+
+    /**
      * Set the $maxDistance option for $near or $nearSphere criteria.
      *
      * This method must be called after near() or nearSphere(), since placement
@@ -624,6 +639,21 @@ class Expr
             $query['$maxDistance'] = $maxDistance;
         }
 
+        return $this;
+    }
+
+    /**
+     * Updates the value of the field to a specified value if the specified value is less than the current value of the field.
+     *
+     * @see Builder::min()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/min/
+     * @param mixed $value
+     * @return self
+     */
+    public function min($value)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$min'][$this->currentField] = $value;
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -610,6 +610,23 @@ class Expr
     }
 
     /**
+     * Multiply the current field.
+     *
+     * If the field does not exist, it will be set to 0.
+     *
+     * @see Builder::mul()
+     * @see http://docs.mongodb.org/manual/reference/operator/mul/
+     * @param float|integer $value
+     * @return self
+     */
+    public function mul($value)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$mul'][$this->currentField] = $value;
+        return $this;
+    }
+
+    /**
      * Add $near criteria to the expression.
      *
      * A GeoJSON point may be provided as the first and only argument for

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -219,7 +219,7 @@ class Expr
      * Sets the value of the current field to the current date, either as a date or a timestamp.
      *
      * @see Builder::currentDate()
-     * @see http://docs.mongodb.org/manual/reference/operator/currentDate/
+     * @see http://docs.mongodb.org/manual/reference/operator/update/currentDate/
      * @param bool $useTimestamp
      * @return self
      */

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -867,6 +867,21 @@ class Expr
     }
 
     /**
+     * Add $position criteria to the expression for a $push operation.
+     *
+     * This is useful in conjunction with {@link Expr::each()} for a
+     * {@link Expr::push()} operation.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/update/position/
+     * @param integer $position
+     * @return self
+     */
+    public function position($position)
+    {
+        return $this->operator('$position', $position);
+    }
+
+    /**
      * Remove all elements matching the given value or expression from the
      * current array field.
      *

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -162,6 +162,60 @@ class Expr
     }
 
     /**
+     * Apply a bitwise operation on the current field
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param string $operator
+     * @param int $value
+     * @return self
+     */
+    protected function bit($operator, $value)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$bit'][$this->currentField][$operator] = $value;
+        return $this;
+    }
+
+    /**
+     * Apply a bitwise and operation on the current field.
+     *
+     * @see Builder::bitAnd()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitAnd($value)
+    {
+        return $this->bit('and', $value);
+    }
+
+    /**
+     * Apply a bitwise or operation on the current field.
+     *
+     * @see Builder::bitOr()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitOr($value)
+    {
+        return $this->bit('or', $value);
+    }
+
+    /**
+     * Apply a bitwise xor operation on the current field.
+     *
+     * @see Builder::bitXor()
+     * @see http://docs.mongodb.org/manual/reference/operator/update/bit/
+     * @param int $value
+     * @return self
+     */
+    public function bitXor($value)
+    {
+        return $this->bit('xor', $value);
+    }
+
+    /**
      * Sets the value of the current field to the current date, either as a date or a timestamp.
      *
      * @see Builder::currentDate()

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -162,6 +162,21 @@ class Expr
     }
 
     /**
+     * Sets the value of the current field to the current date, either as a date or a timestamp.
+     *
+     * @see Builder::currentDate()
+     * @see http://docs.mongodb.org/manual/reference/operator/currentDate/
+     * @param bool $useTimestamp
+     * @return self
+     */
+    public function currentDate($useTimestamp = false)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$currentDate'][$this->currentField]['$type'] = $useTimestamp ? 'timestamp' : 'date';
+        return $this;
+    }
+
+    /**
      * Add $each criteria to the expression for a $push operation.
      *
      * @see Expr::push()

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -708,6 +708,60 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
+    public function testBitAndUpdateQuery()
+    {
+        $qb = $this->getTestQueryBuilder()
+            ->update()
+            ->field('flags')->bitAnd(15)
+            ->field('username')->equals('boo');
+
+        $expected = array(
+            'username' => 'boo'
+        );
+        $this->assertEquals($expected, $qb->getQueryArray());
+
+        $expected = array('$bit' => array(
+            'flags' => array('and' => 15)
+        ));
+        $this->assertEquals($expected, $qb->getNewObj());
+    }
+
+    public function testBitOrUpdateQuery()
+    {
+        $qb = $this->getTestQueryBuilder()
+            ->update()
+            ->field('flags')->bitOr(15)
+            ->field('username')->equals('boo');
+
+        $expected = array(
+            'username' => 'boo'
+        );
+        $this->assertEquals($expected, $qb->getQueryArray());
+
+        $expected = array('$bit' => array(
+            'flags' => array('or' => 15)
+        ));
+        $this->assertEquals($expected, $qb->getNewObj());
+    }
+
+    public function testBitXorUpdateQuery()
+    {
+        $qb = $this->getTestQueryBuilder()
+            ->update()
+            ->field('flags')->bitXor(15)
+            ->field('username')->equals('boo');
+
+        $expected = array(
+            'username' => 'boo'
+        );
+        $this->assertEquals($expected, $qb->getQueryArray());
+
+        $expected = array('$bit' => array(
+            'flags' => array('xor' => 15)
+        ));
+        $this->assertEquals($expected, $qb->getNewObj());
+    }
+
     public static function provideCurrentDateOptions()
     {
         return array(

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -348,6 +348,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'geoWithinCenterSphere()' => array('geoWithinCenterSphere', array(1, 2, 3)),
             'geoWithinPolygon()' => array('geoWithinPolygon', array(array(0, 0), array(1, 1), array(1, 0))),
             'inc()' => array('inc', array(1)),
+            'mul()' => array('mul', array(1)),
             'unsetField()' => array('unsetField'),
             'push() with value' => array('push', array('value')),
             'push() with Expr' => array('push', array($this->getMockExpr())),

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -371,6 +371,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'not()' => array('not', array($this->getMockExpr())),
             'language()' => array('language', array('en')),
             'text()' => array('text', array('foo')),
+            'max()' => array('max', array(1)),
+            'min()' => array('min', array(1)),
         );
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -687,6 +687,35 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('score' => array('$meta' => 'textScore')), $qb->debug('sort'));
     }
 
+    /**
+     * @dataProvider provideCurrentDateOptions
+     */
+    public function testCurrentDateUpdateQuery($timestamp, $expectedType)
+    {
+        $qb = $this->getTestQueryBuilder()
+            ->update()
+            ->field('lastUpdated')->currentDate($timestamp)
+            ->field('username')->equals('boo');
+
+        $expected = array(
+            'username' => 'boo'
+        );
+        $this->assertEquals($expected, $qb->getQueryArray());
+
+        $expected = array('$currentDate' => array(
+            'lastUpdated' => array('$type' => $expectedType)
+        ));
+        $this->assertEquals($expected, $qb->getNewObj());
+    }
+
+    public static function provideCurrentDateOptions()
+    {
+        return array(
+            array(false, 'date'),
+            array(true, 'timestamp')
+        );
+    }
+
     private function getStubQueryBuilder()
     {
         return new BuilderStub($this->getMockCollection());

--- a/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
@@ -332,6 +332,25 @@ class ExprTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedNewObj, $expr->getNewObj());
     }
 
+    public function testPushWithPosition()
+    {
+        $expr = new Expr();
+        $innerExpr = new Expr();
+        $innerExpr
+            ->each(array(20, 30))
+            ->position(0);
+
+        $expectedNewObj = array(
+            '$push' => array('a' => array(
+                '$each' => array(20, 30),
+                '$position' => 0,
+            )),
+        );
+
+        $this->assertSame($expr, $expr->field('a')->push($innerExpr));
+        $this->assertEquals($expectedNewObj, $expr->getNewObj());
+    }
+
     /**
      * @dataProvider provideGeoJsonPolygon
      */


### PR DESCRIPTION
This PR adds support for the ```$bit```, ```$currentDate```, ```$max```, ```$min```, ```$mul``` and ```$position``` update operators added in MongoDB 2.6.

Fixes #136.