### PR TITLE
Test with lowest dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ services: mongodb
 before_script:
   - yes '' | pecl -q install -f mongo-${MONGO_VERSION}
   - php --ri mongo
+  - composer self-update
   - composer update --dev --no-interaction --prefer-source $PREFER_LOWEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,16 @@ php:
   - 5.6
 
 env:
-  - MONGO_VERSION=1.2.12
-  - MONGO_VERSION=1.3.2
-  - MONGO_VERSION=1.3.7
-  - MONGO_VERSION=1.4.5
-  - MONGO_VERSION=stable
+  - MONGO_VERSION=1.2.12 PREFER_LOWEST=""
+  - MONGO_VERSION=1.3.2 PREFER_LOWEST=""
+  - MONGO_VERSION=1.3.7 PREFER_LOWEST=""
+  - MONGO_VERSION=1.4.5 PREFER_LOWEST=""
+  - MONGO_VERSION=stable PREFER_LOWEST=""
+  - MONGO_VERSION=stable PREFER_LOWEST="--prefer-lowest"
 
 services: mongodb
 
 before_script:
   - yes '' | pecl -q install -f mongo-${MONGO_VERSION}
   - php --ri mongo
-  - composer install --dev --no-interaction --prefer-source
+  - composer update --dev --no-interaction --prefer-source $PREFER_LOWEST

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "ext-mongo": ">=1.2.12,<1.7-dev",
-        "doctrine/common": "~2.1"
+        "doctrine/common": "~2.2"
     },
     "require-dev": {
         "jmikola/geojson": "~1.0"


### PR DESCRIPTION
Run library against `lowest` dependencies using `mongo stable` version.
This will find out if lowest dependencies need to be updated.

 - [x] composer is now updated on every build.
 - [x] Update `doctrine/common` min dependency to `~2.2`.

Can check build failing for 2.1 [here](https://travis-ci.org/amyboyd/mongrate/jobs/62818098#L124)
