### PR TITLE
Change parameter for $currentDate operator

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -232,12 +232,12 @@ class Builder
      *
      * @see Expr::currentDate()
      * @see http://docs.mongodb.org/manual/reference/operator/currentDate/
-     * @param bool $useTimestamp
+     * @param string $type
      * @return self
      */
-    public function currentDate($useTimestamp = false)
+    public function currentDate($type = 'date')
     {
-        $this->expr->currentDate($useTimestamp);
+        $this->expr->currentDate($type);
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -220,13 +220,18 @@ class Expr
      *
      * @see Builder::currentDate()
      * @see http://docs.mongodb.org/manual/reference/operator/update/currentDate/
-     * @param bool $useTimestamp
+     * @param string $type
      * @return self
+     * @throws InvalidArgumentException if an invalid type is given
      */
-    public function currentDate($useTimestamp = false)
+    public function currentDate($type = 'date')
     {
+        if (!in_array($type, array('date', 'timestamp'))) {
+            throw new InvalidArgumentException('Type for currentDate operator must be date or timestamp.');
+        }
+
         $this->requiresCurrentField();
-        $this->newObj['$currentDate'][$this->currentField]['$type'] = $useTimestamp ? 'timestamp' : 'date';
+        $this->newObj['$currentDate'][$this->currentField]['$type'] = $type;
         return $this;
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -692,11 +692,11 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideCurrentDateOptions
      */
-    public function testCurrentDateUpdateQuery($timestamp, $expectedType)
+    public function testCurrentDateUpdateQuery($type)
     {
         $qb = $this->getTestQueryBuilder()
             ->update()
-            ->field('lastUpdated')->currentDate($timestamp)
+            ->field('lastUpdated')->currentDate($type)
             ->field('username')->equals('boo');
 
         $expected = array(
@@ -705,9 +705,27 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $qb->getQueryArray());
 
         $expected = array('$currentDate' => array(
-            'lastUpdated' => array('$type' => $expectedType)
+            'lastUpdated' => array('$type' => $type)
         ));
         $this->assertEquals($expected, $qb->getNewObj());
+    }
+
+    public static function provideCurrentDateOptions()
+    {
+        return array(
+            array('date'),
+            array('timestamp')
+        );
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCurrentDateInvalidType()
+    {
+        $this->getTestQueryBuilder()
+            ->update()
+            ->field('lastUpdated')->currentDate('notADate');
     }
 
     public function testBitAndUpdateQuery()
@@ -762,14 +780,6 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'flags' => array('xor' => 15)
         ));
         $this->assertEquals($expected, $qb->getNewObj());
-    }
-
-    public static function provideCurrentDateOptions()
-    {
-        return array(
-            array(false, 'date'),
-            array(true, 'timestamp')
-        );
     }
 
     private function getStubQueryBuilder()


### PR DESCRIPTION
This changes the $currentDate operator to no longer accept a timestamp parameter, instead accepting the type directly.

Fixes #217