### PR TITLE
Include all cursor methods in cursor interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: php
 
 php:

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -53,6 +53,16 @@ class Cursor implements CursorInterface
      */
     protected $numRetries;
 
+    /**
+     * Whether to use the document's "_id" value as its iteration key.
+     *
+     * If false, the position of the document in the result set will be reported
+     * instead. This is useful for documents that have non-scalar IDs.
+     *
+     * @var boolean
+     */
+    protected $useIdentifierKeys = true;
+
     protected $query = array();
     protected $fields = array();
     protected $hint;
@@ -309,11 +319,18 @@ class Cursor implements CursorInterface
     public function getSingleResult()
     {
         $originalLimit = $this->limit;
+        $originalUseIdentifierKeys = $this->useIdentifierKeys;
+
         $this->reset();
         $this->limit(1);
-        $result = current($this->toArray(false)) ?: null;
+        $this->setUseIdentifierKeys(false);
+
+        $result = current($this->toArray()) ?: null;
+
         $this->reset();
         $this->limit($originalLimit);
+        $this->setUseIdentifierKeys($originalUseIdentifierKeys);
+
         return $result;
     }
 
@@ -376,10 +393,17 @@ class Cursor implements CursorInterface
      *
      * @see http://php.net/manual/en/iterator.key.php
      * @see http://php.net/manual/en/mongocursor.key.php
-     * @return string
+     * @return mixed
      */
     public function key()
     {
+        // TODO: Track position internally to avoid repeated info() calls
+        if ( ! $this->useIdentifierKeys) {
+            $info = $this->mongoCursor->info();
+
+            return isset($info['at']) ? $info['at'] : null;
+        }
+
         return $this->mongoCursor->key();
     }
 
@@ -521,6 +545,20 @@ class Cursor implements CursorInterface
     }
 
     /**
+     * Set whether to use the document's "_id" value as its iteration key.
+     *
+     * @since 1.2
+     * @param boolean $useIdentifierKeys
+     * @return self
+     */
+    public function setUseIdentifierKeys($useIdentifierKeys)
+    {
+        $this->useIdentifierKeys = (boolean) $useIdentifierKeys;
+
+        return $this;
+    }
+
+    /**
      * Wrapper method for MongoCursor::skip().
      *
      * @see http://php.net/manual/en/mongocursor.skip.php
@@ -618,20 +656,29 @@ class Cursor implements CursorInterface
     /**
      * Return the cursor's results as an array.
      *
-     * If documents in the result set use BSON objects for their "_id", the
-     * $useKeys parameter may be set to false to avoid errors attempting to cast
-     * arrays (i.e. BSON objects) to string keys.
-     *
      * @see Iterator::toArray()
-     * @param boolean $useKeys
+     * @param boolean $useIdentifierKeys Deprecated since 1.2; will be removed in 2.0
      * @return array
      */
-    public function toArray($useKeys = true)
+    public function toArray($useIdentifierKeys = null)
     {
+        $originalUseIdentifierKeys = $this->useIdentifierKeys;
+        $useIdentifierKeys = isset($useIdentifierKeys) ? (boolean) $useIdentifierKeys : $this->useIdentifierKeys;
         $cursor = $this;
-        return $this->retry(function() use ($cursor, $useKeys) {
-            return iterator_to_array($cursor, $useKeys);
+
+        /* Let iterator_to_array() decide to use keys or not. This will avoid
+         * superfluous MongoCursor::info() from the key() method until the
+         * cursor position is tracked internally.
+         */
+        $this->useIdentifierKeys = true;
+
+        $results = $this->retry(function() use ($cursor, $useIdentifierKeys) {
+            return iterator_to_array($cursor, $useIdentifierKeys);
         }, true);
+
+        $this->useIdentifierKeys = $originalUseIdentifierKeys;
+
+        return $results;
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -181,6 +181,8 @@ class Cursor implements CursorInterface
     /**
      * Wrapper method for MongoCursor::fields().
      *
+     * @param array $f Fields to return (or not return).
+     *
      * @see http://php.net/manual/en/mongocursor.fields.php
      * @return self
      */
@@ -406,7 +408,7 @@ class Cursor implements CursorInterface
     {
         $cursor = $this;
         $this->retry(function() use ($cursor) {
-            return $cursor->getMongoCursor()->next();
+            $cursor->getMongoCursor()->next();
         }, false);
     }
 
@@ -480,7 +482,7 @@ class Cursor implements CursorInterface
     {
         $cursor = $this;
         $this->retry(function() use ($cursor) {
-            return $cursor->getMongoCursor()->rewind();
+            $cursor->getMongoCursor()->rewind();
         }, false);
     }
 

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -19,12 +19,10 @@
 
 namespace Doctrine\MongoDB;
 
-use Doctrine\MongoDB\Util\ReadPreference;
-
 /**
  * Wrapper for the PHP MongoCursor class.
  *
- * @since  1.0
+ * @since  1.2
  * @author alcaeus <alcaeus@alcaeus.org>
  */
 interface CursorInterface extends Iterator
@@ -76,10 +74,41 @@ interface CursorInterface extends Iterator
     /**
      * Wrapper method for MongoCursor::fields().
      *
+     * @param array $f Fields to return (or not return).
+     *
      * @see http://php.net/manual/en/mongocursor.fields.php
      * @return self
      */
     public function fields(array $f);
+
+    /**
+     * Return the collection for this cursor.
+     *
+     * @return Collection
+     */
+    public function getCollection();
+
+    /**
+     * Return the selected fields (projection).
+     *
+     * @return array
+     */
+    public function getFields();
+
+    /**
+     * Wrapper method for MongoCursor::getNext().
+     *
+     * @see http://php.net/manual/en/mongocursor.getnext.php
+     * @return array|null
+     */
+    public function getNext();
+
+    /**
+     * Return the query criteria.
+     *
+     * @return array
+     */
+    public function getQuery();
 
     /**
      * Wrapper method for MongoCursor::getReadPreference().
@@ -98,6 +127,14 @@ interface CursorInterface extends Iterator
      * @return self
      */
     public function setReadPreference($readPreference, array $tags = null);
+
+    /**
+     * Wrapper method for MongoCursor::hasNext().
+     *
+     * @see http://php.net/manual/en/mongocursor.hasnext.php
+     * @return boolean
+     */
+    public function hasNext();
 
     /**
      * Wrapper method for MongoCursor::hint().
@@ -133,6 +170,11 @@ interface CursorInterface extends Iterator
      * @return self
      */
     public function limit($num);
+
+    /**
+     * Recreates the internal MongoCursor.
+     */
+    public function recreate();
 
     /**
      * Wrapper method for MongoCursor::reset().

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -185,6 +185,15 @@ interface CursorInterface extends Iterator
     public function reset();
 
     /**
+     * Set whether to use the document's "_id" value as its iteration key.
+     *
+     * @since 1.2
+     * @param boolean $useIdentifierKeys
+     * @return self
+     */
+    public function setUseIdentifierKeys($useIdentifierKeys);
+
+    /**
      * Wrapper method for MongoCursor::skip().
      *
      * @see http://php.net/manual/en/mongocursor.skip.php

--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -31,7 +31,7 @@ class EagerCursor implements CursorInterface
     /**
      * The Cursor instance being wrapped.
      *
-     * @var Cursor
+     * @var CursorInterface
      */
     protected $cursor;
 
@@ -73,10 +73,10 @@ class EagerCursor implements CursorInterface
      * $useKeys parameter may be set to false to avoid errors attempting to cast
      * arrays (i.e. BSON objects) to string keys.
      *
-     * @param Cursor $cursor
+     * @param CursorInterface $cursor
      * @param boolean $useKeys
      */
-    public function __construct(Cursor $cursor, $useKeys = true)
+    public function __construct(CursorInterface $cursor, $useKeys = true)
     {
         $this->cursor = $cursor;
         $this->useKeys = (boolean) $useKeys;
@@ -105,7 +105,7 @@ class EagerCursor implements CursorInterface
     /**
      * Return the wrapped Cursor.
      *
-     * @return Cursor
+     * @return CursorInterface
      */
     public function getCursor()
     {

--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -50,17 +50,9 @@ class EagerCursor implements CursorInterface
     protected $initialized = false;
 
     /**
-     * Whether to preserve keys from the Cursor (i.e. "_id" values) when
-     * initializing the $data array.
+     * Whether the cursor has started iterating.
      *
-     * @var boolean
-     */
-    protected $useKeys = true;
-
-    /**
-     * Whether the cursor started iterating.
-     *
-     * This is necessary to get getNext() and hasNext() to work properly
+     * This is necessary for getNext() and hasNext() to work properly.
      *
      * @var boolean
      */
@@ -69,17 +61,11 @@ class EagerCursor implements CursorInterface
     /**
      * Constructor.
      *
-     * If documents in the result set use BSON objects for their "_id", the
-     * $useKeys parameter may be set to false to avoid errors attempting to cast
-     * arrays (i.e. BSON objects) to string keys.
-     *
      * @param CursorInterface $cursor
-     * @param boolean $useKeys
      */
-    public function __construct(CursorInterface $cursor, $useKeys = true)
+    public function __construct(CursorInterface $cursor)
     {
         $this->cursor = $cursor;
-        $this->useKeys = (boolean) $useKeys;
     }
 
     /**
@@ -132,7 +118,7 @@ class EagerCursor implements CursorInterface
     public function initialize()
     {
         if ($this->initialized === false) {
-            $this->data = $this->cursor->toArray($this->useKeys);
+            $this->data = $this->cursor->toArray();
         }
         $this->initialized = true;
     }
@@ -375,6 +361,16 @@ class EagerCursor implements CursorInterface
     public function reset()
     {
         $this->cursor->reset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUseIdentifierKeys($useIdentifierKeys)
+    {
+        $this->cursor->setUseIdentifierKeys($useIdentifierKeys);
+
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -21,6 +21,7 @@ namespace Doctrine\MongoDB\Query;
 
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Cursor;
+use Doctrine\MongoDB\CursorInterface;
 use Doctrine\MongoDB\Database;
 use Doctrine\MongoDB\EagerCursor;
 use Doctrine\MongoDB\Iterator;
@@ -152,7 +153,7 @@ class Query implements IteratorAggregate
      * (e.g. aggregate, inline mapReduce) may return an ArrayIterator. Other
      * commands and operations may return a status array or a boolean, depending
      * on the driver's write concern. Queries and some mapReduce commands will
-     * return a Cursor.
+     * return a CursorInterface.
      *
      * @return mixed
      */
@@ -382,7 +383,7 @@ class Query implements IteratorAggregate
      * array. The Cursor may also be wrapped with an EagerCursor.
      *
      * @param Cursor $cursor
-     * @return Cursor|EagerCursor
+     * @return CursorInterface
      */
     protected function prepareCursor(Cursor $cursor)
     {

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -403,8 +403,11 @@ class Query implements IteratorAggregate
         }
 
         if ( ! empty($this->query['eagerCursor'])) {
-            $useKeys = isset($this->query['useKeys']) && $this->query['useKeys'];
-            $cursor = new EagerCursor($cursor, $useKeys);
+            $cursor = new EagerCursor($cursor);
+        }
+
+        if (isset($this->query['useIdentifierKeys'])) {
+            $cursor->setUseIdentifierKeys($this->query['useIdentifierKeys']);
         }
 
         return $cursor;

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -87,20 +87,48 @@ class CursorTest extends BaseTest
         $this->assertNotNull($cursor->getSingleResult());
     }
 
+    public function testSetUseIdentifierKeys()
+    {
+        $this->cursor->setUseIdentifierKeys(false);
+
+        foreach ($this->cursor as $key => $document) {
+            /* Note: Driver versions before 1.5.0 had an off-by-one error and
+             * count from one, so just assert the key's type here.
+             */
+            $this->assertTrue(is_integer($key));
+        }
+    }
+
     public function testToArray()
     {
         $this->assertEquals(
             array(
                 (string) $this->doc1['_id'] => $this->doc1,
                 (string) $this->doc2['_id'] => $this->doc2,
-                (string) $this->doc3['_id'] => $this->doc3
+                (string) $this->doc3['_id'] => $this->doc3,
             ),
             $this->cursor->toArray()
         );
     }
 
-    public function testToArrayWithoutKeys()
+    public function testToArrayWithKeysOverridesClassOption()
     {
+        $this->cursor->setUseIdentifierKeys(false);
+
+        $this->assertEquals(
+            array(
+                (string) $this->doc1['_id'] => $this->doc1,
+                (string) $this->doc2['_id'] => $this->doc2,
+                (string) $this->doc3['_id'] => $this->doc3,
+            ),
+            $this->cursor->toArray(true)
+        );
+    }
+
+    public function testToArrayWithoutKeysOverridesClassOption()
+    {
+        $this->cursor->setUseIdentifierKeys(false);
+
         $this->assertEquals(array($this->doc1, $this->doc2, $this->doc3), $this->cursor->toArray(false));
     }
 

--- a/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
@@ -20,7 +20,6 @@ class EagerCursorTest extends BaseTest
 
         $cursor->expects($this->once())
             ->method('toArray')
-            ->with(true) // Constructor $useKeys option defaults to true
             ->will($this->returnValue(array()));
 
         $eagerCursor = new EagerCursor($cursor);
@@ -30,29 +29,6 @@ class EagerCursorTest extends BaseTest
         $this->assertTrue($eagerCursor->isInitialized());
         $eagerCursor->initialize();
         $this->assertTrue($eagerCursor->isInitialized());
-    }
-
-    /**
-     * @dataProvider provideUseKeys
-     */
-    public function testInitializationForwardsUseKeysOption($useKeys)
-    {
-        $cursor = $this->getMockCursor();
-
-        $cursor->expects($this->once())
-            ->method('toArray')
-            ->with($useKeys);
-
-        $eagerCursor = new EagerCursor($cursor, $useKeys);
-        $eagerCursor->initialize();
-    }
-
-    public function provideUseKeys()
-    {
-        return array(
-            array(true),
-            array(false),
-        );
     }
 
     public function testCount()
@@ -73,6 +49,23 @@ class EagerCursorTest extends BaseTest
         $this->assertFalse($eagerCursor->isInitialized());
         $this->assertEquals(2, count($eagerCursor));
         $this->assertTrue($eagerCursor->isInitialized());
+    }
+
+    public function testSetUseIdentifierKeys()
+    {
+        $cursor = $this->getMockCursor();
+
+        $cursor->expects($this->at(0))
+            ->method('setUseIdentifierKeys')
+            ->with(true);
+
+        $cursor->expects($this->at(1))
+            ->method('setUseIdentifierKeys')
+            ->with(false);
+
+        $eagerCursor = new EagerCursor($cursor);
+        $eagerCursor->setUseIdentifierKeys(true);
+        $eagerCursor->setUseIdentifierKeys(false);
     }
 
     public function testGetSingleResultShouldAlwaysReturnTheFirstResult()
@@ -197,7 +190,7 @@ class EagerCursorTest extends BaseTest
      */
     private function getMockCursor()
     {
-        return $this->getMockBuilder('Doctrine\MongoDB\Cursor')
+        return $this->getMockBuilder('Doctrine\MongoDB\CursorInterface')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
@@ -162,6 +162,36 @@ class EagerCursorTest extends BaseTest
         }
     }
 
+    public function testGetNextHasNext()
+    {
+        $results = array(
+            array('_id' => 1, 'x' => 'foo'),
+            array('_id' => 2, 'x' => 'bar'),
+        );
+
+        $cursor = $this->getMockCursor();
+
+        $cursor->expects($this->once())
+            ->method('toArray')
+            ->will($this->returnValue($results));
+
+        $eagerCursor = new EagerCursor($cursor);
+
+        $this->assertTrue($eagerCursor->hasNext());
+        $this->assertEquals($results[0], $eagerCursor->getNext());
+
+        $this->assertTrue($eagerCursor->hasNext());
+        $this->assertEquals($results[0], $eagerCursor->current(), 'hasNext does not advance internal cursor');
+        $this->assertEquals($results[1], $eagerCursor->getNext());
+
+        $this->assertFalse($eagerCursor->hasNext());
+        $this->assertNull($eagerCursor->getNext());
+
+        $eagerCursor->rewind();
+        $this->assertTrue($eagerCursor->hasNext());
+        $this->assertEquals($results[0], $eagerCursor->getNext());
+    }
+
     /**
      * @return \Doctrine\MongoDB\Cursor
      */

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -260,6 +260,32 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($cursor, $eagerCursor->getCursor());
     }
 
+    public function testUseIdentifierKeys()
+    {
+        $cursor = $this->getMockCursor();
+        $collection = $this->getMockCollection();
+
+        $collection->expects($this->once())
+            ->method('find')
+            ->with(array('foo' => 'bar'))
+            ->will($this->returnValue($cursor));
+
+        $cursor->expects($this->once())
+            ->method('setUseIdentifierKeys')
+            ->with(false)
+            ->will($this->returnValue($cursor));
+
+        $queryArray = array(
+            'type' => Query::TYPE_FIND,
+            'query' => array('foo' => 'bar'),
+            'useIdentifierKeys' => false,
+        );
+
+        $query = new Query($collection, $queryArray, array());
+
+        $this->assertSame($cursor, $query->execute());
+    }
+
     /**
      * @return \Doctrine\MongoDB\Collection
      */


### PR DESCRIPTION
This extends the common cursor interface introduced in #209 to include all methods currently available in the cursor. This makes the ```Cursor``` and ```EagerCursor``` more interchangeable in ODM, allowing us to plug both classes into ```ODM\Cursor``` once that has been adapted.

The ```hasNext``` and ```getNext``` methods have to be simulated by advancing and rewinding the array pointer as well as checking if the cursor has started iterating.