### PR TITLE
Specify time limit operation on a mongodb cursor

### DIFF
--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -78,6 +78,7 @@ class Cursor implements CursorInterface
     protected $sort;
     protected $tailable;
     protected $timeout;
+    protected $maxTimeMS;
 
     /**
      * Constructor.
@@ -661,6 +662,22 @@ class Cursor implements CursorInterface
     {
         $this->timeout = (integer) $ms;
         $this->mongoCursor->timeout($ms);
+        return $this;
+    }
+
+    /**
+     * Wrapper method for MongoCursor::maxTimeMS().
+     *
+     * @see http://php.net/manual/en/mongocursor.maxtimems.php
+     * @param integer $ms
+     * @return self
+     */
+    public function maxTimeMS($ms)
+    {
+        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
+            $this->maxTimeMS = (integer)$ms;
+            $this->mongoCursor->maxTimeMS((integer)$ms);
+        }
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -509,6 +509,9 @@ class Cursor implements CursorInterface
         if ($this->timeout !== null) {
             $this->mongoCursor->timeout($this->timeout);
         }
+        if ($this->maxTimeMS !== null) {
+            $this->mongoCursor->maxTimeMS($this->maxTimeMS);
+        }
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -510,7 +510,7 @@ class Cursor implements CursorInterface
             $this->mongoCursor->timeout($this->timeout);
         }
         if ($this->maxTimeMS !== null) {
-            $this->mongoCursor->maxTimeMS($this->maxTimeMS);
+            $this->mongoCursor->addOption('$maxTimeMS', $this->maxTimeMS);
         }
     }
 
@@ -677,10 +677,8 @@ class Cursor implements CursorInterface
      */
     public function maxTimeMS($ms)
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
-            $this->maxTimeMS = (integer)$ms;
-            $this->mongoCursor->maxTimeMS((integer)$ms);
-        }
+        $this->maxTimeMS = (integer)$ms;
+        $this->mongoCursor->addOption('$maxTimeMS', (integer)$ms);
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -253,4 +253,13 @@ interface CursorInterface extends Iterator
      * @return self
      */
     public function timeout($ms);
+
+    /**
+     * Wrapper method for MongoCursor::maxTimeMS().
+     *
+     * @see http://php.net/manual/en/mongocursor.maxtimems.php
+     * @param integer $ms
+     * @return self
+     */
+    public function maxTimeMS($ms);
 }

--- a/lib/Doctrine/MongoDB/CursorInterface.php
+++ b/lib/Doctrine/MongoDB/CursorInterface.php
@@ -253,13 +253,4 @@ interface CursorInterface extends Iterator
      * @return self
      */
     public function timeout($ms);
-
-    /**
-     * Wrapper method for MongoCursor::maxTimeMS().
-     *
-     * @see http://php.net/manual/en/mongocursor.maxtimems.php
-     * @param integer $ms
-     * @return self
-     */
-    public function maxTimeMS($ms);
 }

--- a/lib/Doctrine/MongoDB/EagerCursor.php
+++ b/lib/Doctrine/MongoDB/EagerCursor.php
@@ -440,4 +440,15 @@ class EagerCursor implements CursorInterface
 
         return $this;
     }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function maxTimeMS($ms)
+    {
+        $this->cursor->maxTimeMS($ms);
+
+        return $this;
+    }
 }

--- a/lib/Doctrine/MongoDB/LoggableCursor.php
+++ b/lib/Doctrine/MongoDB/LoggableCursor.php
@@ -139,4 +139,17 @@ class LoggableCursor extends Cursor implements Loggable
 
         return parent::sort($fields);
     }
+
+    /**
+     * @see Cursor::maxTimeMS()
+     */
+    public function maxTimeMS($ms)
+    {
+        $this->log(array(
+            'maxTimeMS' => true,
+            'maxTimeMSNum' => $ms,
+        ));
+
+        return parent::maxTimeMS($ms);
+    }
 }

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -739,6 +739,18 @@ class Builder
     }
 
     /**
+     * Specifies a cumulative time limit in milliseconds for processing operations on a cursor.
+     *
+     * @param int $ms
+     * @return $this
+     */
+    public function maxTimeMS($ms)
+    {
+        $this->query['maxTimeMS'] = $ms;
+        return $this;
+    }
+
+    /**
      * Set the immortal cursor flag.
      *
      * @param boolean $bool

--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -395,7 +395,7 @@ class Query implements IteratorAggregate
             $cursor->setReadPreference($this->query['readPreference'], $this->query['readPreferenceTags']);
         }
 
-        foreach ($this->getQueryOptions('hint', 'immortal', 'limit', 'skip', 'slaveOkay', 'sort') as $key => $value) {
+        foreach ($this->getQueryOptions('hint', 'immortal', 'limit', 'skip', 'slaveOkay', 'sort', 'maxTimeMS') as $key => $value) {
             $cursor->$key($value);
         }
 

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -342,6 +342,9 @@ class CursorTest extends BaseTest
             $mongoCursor->expects($self->once())
                 ->method('timeout')
                 ->with(1000);
+            $mongoCursor->expects($self->once())
+                ->method('maxTimeMS')
+                ->with(30000);
         };
 
         $mongoCursor = $this->getMockMongoCursor();
@@ -376,7 +379,8 @@ class CursorTest extends BaseTest
             ->snapshot()
             ->sort(array('x' => -1))
             ->tailable(false)
-            ->timeout(1000);
+            ->timeout(1000)
+            ->maxTimeMS(30000);
 
         $cursor->recreate();
     }

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -383,16 +383,15 @@ class CursorTest extends BaseTest
 
     public function testSetMaxTimeMSWhenRecreateCursor()
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
         $self = $this;
 
         $setCursorExpectations = function($mongoCursor) use ($self) {
             $mongoCursor->expects($self->once())
-                ->method('maxTimeMS')
-                ->with(30000);
+                ->method('addOption')
+                ->with(
+                    $self->equalTo('$maxTimeMS'),
+                    $self->equalTo(30000)
+                );
         };
 
         $mongoCursor = $this->getMockMongoCursor();

--- a/tests/Doctrine/MongoDB/Tests/LoggableCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableCursorTest.php
@@ -23,6 +23,7 @@ class LoggableCursorTest extends BaseTest
             array('limit'),
             array('hint', array()),
             array('snapshot'),
+            array('maxTimeMS', array())
         );
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -288,10 +288,6 @@ class QueryTest extends \PHPUnit_Framework_TestCase
 
     public function testSpecifyMaxTimeMSOnCursor()
     {
-        if(version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
         $cursor = $this->getMockCursor();
         $collection = $this->getMockCollection();
 

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -286,6 +286,36 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($cursor, $query->execute());
     }
 
+    public function testSpecifyMaxTimeMSOnCursor()
+    {
+        if(version_compare(phpversion('mongo'), '1.5.0', '<')) {
+            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
+        }
+
+        $cursor = $this->getMockCursor();
+        $collection = $this->getMockCollection();
+
+        $collection->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo(array('foo' => 'bar')))
+            ->will($this->returnValue($cursor));
+
+        $cursor->expects($this->once())
+            ->method('maxTimeMS')
+            ->with($this->equalTo(30000))
+            ->will($this->returnValue($cursor));
+
+        $queryArray = array(
+            'type' => Query::TYPE_FIND,
+            'query' => array('foo' => 'bar'),
+            'maxTimeMS' => 30000
+        );
+
+        $query = new Query($collection, $queryArray, array());
+
+        $this->assertSame($cursor, $query->execute());
+    }
+
     /**
      * @return \Doctrine\MongoDB\Collection
      */


### PR DESCRIPTION
Termination processing operation if the associated cursor exceeds its allotted time limit. It is beneficial when PHP driver goes on timeout (by default 30 seconds). As a results mongodb keep health on highload projects because of not performing not needed operations.

Thanks. Sorry for my english.