### PR TITLE
Add support for the $comment operator

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -217,6 +217,20 @@ class Builder
     }
 
     /**
+     * Associates a comment to any expression taking a query predicate.
+     *
+     * @see Expr::comment()
+     * @see http://docs.mongodb.org/manual/reference/operator/query/comment/
+     * @param string $comment
+     * @return self
+     */
+    public function comment($comment)
+    {
+        $this->expr->comment($comment);
+        return $this;
+    }
+
+    /**
      * Change the query type to count.
      *
      * @return self

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -216,6 +216,20 @@ class Expr
     }
 
     /**
+     * Associates a comment to any expression taking a query predicate.
+     *
+     * @see Builder::comment()
+     * @see http://docs.mongodb.org/manual/reference/operator/query/comment/
+     * @param string $comment
+     * @return self
+     */
+    public function comment($comment)
+    {
+        $this->query['$comment'] = $comment;
+        return $this;
+    }
+
+    /**
      * Sets the value of the current field to the current date, either as a date or a timestamp.
      *
      * @see Builder::currentDate()

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -373,6 +373,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'text()' => array('text', array('foo')),
             'max()' => array('max', array(1)),
             'min()' => array('min', array(1)),
+            'comment()' => array('comment', array('A comment explaining what the query does'))
         );
     }
 


### PR DESCRIPTION
As mentioned in doctrine/mongodb-odm#1224, there is no support for the $coment operator that was introduced in 2.4. This PR fixes that.