### PR TITLE
Add support for $setOnInsert operator

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -1421,6 +1421,26 @@ class Builder
     }
 
     /**
+     * Set the current field to the value if the document is inserted in an
+     * upsert operation.
+     *
+     * If an update operation with upsert: true results in an insert of a
+     * document, then $setOnInsert assigns the specified values to the fields in
+     * the document. If the update operation does not result in an insert,
+     * $setOnInsert does nothing.
+     *
+     * @see Expr::setOnInsert()
+     * @see https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/
+     * @param mixed $value
+     * @return self
+     */
+    public function setOnInsert($value)
+    {
+        $this->expr->setOnInsert($value);
+        return $this;
+    }
+
+    /**
      * Set the read preference for the query.
      *
      * This is only relevant for read-only queries and commands.

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -1046,6 +1046,28 @@ class Expr
     }
 
     /**
+     * Set the current field to the value if the document is inserted in an
+     * upsert operation.
+     *
+     * If an update operation with upsert: true results in an insert of a
+     * document, then $setOnInsert assigns the specified values to the fields in
+     * the document. If the update operation does not result in an insert,
+     * $setOnInsert does nothing.
+     *
+     * @see Builder::setOnInsert()
+     * @see https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/
+     * @param mixed $value
+     * @return self
+     */
+    public function setOnInsert($value)
+    {
+        $this->requiresCurrentField();
+        $this->newObj['$setOnInsert'][$this->currentField] = $value;
+
+        return $this;
+    }
+
+    /**
      * Specify $size criteria for the current field.
      *
      * @see Builder::size()

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -261,6 +261,26 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $qb->getNewObj());
     }
 
+    public function testSetOnInsert()
+    {
+        $createDate = new \MongoDate();
+        $qb = $this->getTestQueryBuilder()
+            ->update()
+            ->upsert()
+            ->field('username')->equals('boo')
+            ->field('createDate')->setOnInsert($createDate);
+
+        $expected = array(
+            'username' => 'boo'
+        );
+        $this->assertEquals($expected, $qb->getQueryArray());
+
+        $expected = array('$setOnInsert' => array(
+            'createDate' => $createDate
+        ));
+        $this->assertEquals($expected, $qb->getNewObj());
+    }
+
     public function testDateRange()
     {
         $start = new \MongoDate(strtotime('1985-09-01 01:00:00'));
@@ -350,6 +370,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'inc()' => array('inc', array(1)),
             'mul()' => array('mul', array(1)),
             'unsetField()' => array('unsetField'),
+            'setOnInsert()' => array('setOnInsert', array(1)),
             'push() with value' => array('push', array('value')),
             'push() with Expr' => array('push', array($this->getMockExpr())),
             'pushAll()' => array('pushAll', array(array('value1', 'value2'))),

--- a/tests/Doctrine/MongoDB/Tests/Query/FunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/FunctionalTest.php
@@ -43,17 +43,18 @@ class FunctionalTest extends BaseTest
     public function testFindAndUpdateQuery()
     {
         $qb = $this->getTestQueryBuilder()
-            ->findAndRemove()
-            ->field('username')->equals('jwage');
+            ->findAndUpdate()
+            ->field('username')->equals('jwage')
+            ->field('writes')->inc(1);
 
-        $this->assertEquals(Query::TYPE_FIND_AND_REMOVE, $qb->getType());
+        $this->assertEquals(Query::TYPE_FIND_AND_UPDATE, $qb->getType());
         $expected = array(
             'username' => 'jwage'
         );
         $this->assertEquals($expected, $qb->getQueryArray());
 
         $query = $qb->getQuery();
-        $this->assertEquals(Query::TYPE_FIND_AND_REMOVE, $query->getType());
+        $this->assertEquals(Query::TYPE_FIND_AND_UPDATE, $query->getType());
         $this->assertNull($query->execute());
     }
 


### PR DESCRIPTION
This PR adds support for the [$etOnInsert operator](https://docs.mongodb.org/manual/reference/operator/update/setOnInsert/) that was added in MongoDB 2.4.