### PR TITLE
Fix bug where timeout is set to 1 ms

### DIFF
--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -9,3 +9,4 @@ in 1.2.x patch versions.
 
  * [#229](https://github.com/doctrine/mongodb/pull/229): Fix EagerCursor::skip() method calling limit method of base cursor instead of skip method
  * [#231](https://github.com/doctrine/mongodb/pull/231): Remove count method declaration in CursorInterface to fix fatal error for PHP 5.3
+ * [#237](https://github.com/doctrine/mongodb/pull/237): Fix bug where timeout is set to 1 ms

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -951,7 +951,7 @@ class Collection
 
         $timeout = isset($clientOptions['socketTimeoutMS'])
             ? $clientOptions['socketTimeoutMS']
-            : (isset($clientOptions['timeout']) ? isset($clientOptions['timeout']) : null);
+            : (isset($clientOptions['timeout']) ? $clientOptions['timeout'] : null);
 
         $mongoCollection = $this->mongoCollection;
         $commandCursor = $this->retry(function() use ($mongoCollection, $pipeline, $commandOptions) {


### PR DESCRIPTION
This was initially introduced as #236 but needs to target 1.2.x support branch.