### PR TITLE
Bump PHP and mongo version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ sudo: false
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
   - 5.6
 
 env:
-  - MONGO_VERSION=1.2.12 PREFER_LOWEST=""
-  - MONGO_VERSION=1.3.2 PREFER_LOWEST=""
-  - MONGO_VERSION=1.3.7 PREFER_LOWEST=""
-  - MONGO_VERSION=1.4.5 PREFER_LOWEST=""
+  - MONGO_VERSION=1.5.8 PREFER_LOWEST=""
   - MONGO_VERSION=stable PREFER_LOWEST=""
   - MONGO_VERSION=stable PREFER_LOWEST="--prefer-lowest"
 

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         { "name": "Andreas Braun", "email": "alcaeus@alcaeus.org" }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "ext-mongo": "^1.2.12",
+        "php": "^5.5",
+        "ext-mongo": "^1.5",
         "doctrine/common": "^2.2"
     },
     "require-dev": {

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -535,10 +535,6 @@ class Collection
      */
     public function getSlaveOkay()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            return $this->mongoCollection->getSlaveOkay();
-        }
-
         $readPref = $this->getReadPreference();
 
         return \MongoClient::RP_PRIMARY !== $readPref['type'];
@@ -558,10 +554,6 @@ class Collection
      */
     public function setSlaveOkay($ok = true)
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            return $this->mongoCollection->setSlaveOkay($ok);
-        }
-
         $prevSlaveOkay = $this->getSlaveOkay();
 
         if ($ok) {
@@ -1468,10 +1460,6 @@ class Collection
      */
     protected function convertWriteConcern(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['safe']) && ! isset($options['w'])) {
             $options['w'] = is_bool($options['safe']) ? (integer) $options['safe'] : $options['safe'];
             unset($options['safe']);
@@ -1489,10 +1477,6 @@ class Collection
      */
     protected function convertWriteTimeout(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['wtimeout']) && ! isset($options['wTimeoutMS'])) {
             $options['wTimeoutMS'] = $options['wtimeout'];
             unset($options['wtimeout']);
@@ -1510,10 +1494,6 @@ class Collection
      */
     protected function convertSocketTimeout(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['timeout']) && ! isset($options['socketTimeoutMS'])) {
             $options['socketTimeoutMS'] = $options['timeout'];
             unset($options['timeout']);

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -722,10 +722,6 @@ class Collection
      */
     public function parallelCollectionScan($numCursors)
     {
-        if ( ! method_exists('MongoCollection', 'parallelCollectionScan')) {
-            throw new BadMethodCallException('MongoCollection::parallelCollectionScan() is not available');
-        }
-
         $mongoCollection = $this->mongoCollection;
         $commandCursors = $this->retry(function() use ($mongoCollection, $numCursors) {
             return $mongoCollection->parallelCollectionScan($numCursors);
@@ -929,10 +925,6 @@ class Collection
      */
     protected function doAggregateCursor(array $pipeline, array $options = array())
     {
-        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
-            throw new BadMethodCallException('MongoCollection::aggregateCursor() is not available');
-        }
-
         list($commandOptions, $clientOptions) = isset($options['socketTimeoutMS']) || isset($options['timeout'])
             ? $this->splitCommandAndClientOptions($options)
             : array($options, array());

--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -30,7 +30,6 @@ use Doctrine\MongoDB\Event\MutableEventArgs;
 use Doctrine\MongoDB\Event\NearEventArgs;
 use Doctrine\MongoDB\Event\UpdateEventArgs;
 use Doctrine\MongoDB\Exception\ResultException;
-use Doctrine\MongoDB\Util\ReadPreference;
 use GeoJson\Geometry\Point;
 use BadMethodCallException;
 use MongoCommandCursor;
@@ -502,7 +501,7 @@ class Collection
      */
     public function getReadPreference()
     {
-        return ReadPreference::convertReadPreference($this->mongoCollection->getReadPreference());
+        return $this->mongoCollection->getReadPreference();
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Connection.php
+++ b/lib/Doctrine/MongoDB/Connection.php
@@ -21,7 +21,6 @@ namespace Doctrine\MongoDB;
 
 use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\Event\EventArgs;
-use Doctrine\MongoDB\Util\ReadPreference;
 
 /**
  * Wrapper for the MongoClient class.
@@ -211,7 +210,7 @@ class Connection
     public function getReadPreference()
     {
         $this->initialize();
-        return ReadPreference::convertReadPreference($this->mongoClient->getReadPreference());
+        return $this->mongoClient->getReadPreference();
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Connection.php
+++ b/lib/Doctrine/MongoDB/Connection.php
@@ -280,9 +280,7 @@ class Connection
         $options = isset($options['wTimeout']) ? $this->convertWriteTimeout($options) : $options;
 
         $this->mongoClient = $this->retry(function() use ($server, $options) {
-            return version_compare(phpversion('mongo'), '1.3.0', '<')
-                ? new \Mongo($server, $options)
-                : new \MongoClient($server, $options);
+            return new \MongoClient($server, $options);
         });
 
         if ($this->eventManager->hasListeners(Events::postConnect)) {
@@ -301,12 +299,7 @@ class Connection
             return false;
         }
 
-        /* MongoClient::$connected is deprecated in 1.5.0+, so count the list of
-         * connected hosts instead.
-         */
-        return version_compare(phpversion('mongo'), '1.5.0', '<')
-            ? $this->mongoClient->connected
-            : count($this->mongoClient->getHosts()) > 0;
+        return count($this->mongoClient->getHosts()) > 0;
     }
 
     /**
@@ -463,10 +456,6 @@ class Connection
      */
     protected function convertConnectTimeout(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.4.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['timeout']) && ! isset($options['connectTimeoutMS'])) {
             $options['connectTimeoutMS'] = $options['timeout'];
             unset($options['timeout']);
@@ -487,10 +476,6 @@ class Connection
      */
     protected function convertWriteTimeout(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.4.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['wTimeout']) && ! isset($options['wTimeoutMS'])) {
             $options['wTimeoutMS'] = $options['wTimeout'];
             unset($options['wTimeout']);

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -19,8 +19,6 @@
 
 namespace Doctrine\MongoDB;
 
-use Doctrine\MongoDB\Util\ReadPreference;
-
 /**
  * Wrapper for the PHP MongoCursor class.
  *
@@ -550,8 +548,7 @@ class Cursor implements CursorInterface
         if ($ok) {
             // Preserve existing tags for non-primary read preferences
             $readPref = $this->mongoCursor->getReadPreference();
-            $tags = !empty($readPref['tagsets']) ? ReadPreference::convertTagSets($readPref['tagsets']) : array();
-            $this->mongoCursor->setReadPreference(\MongoClient::RP_SECONDARY_PREFERRED, $tags);
+            $this->mongoCursor->setReadPreference(\MongoClient::RP_SECONDARY_PREFERRED, isset($readPref['tagsets']) ? $readPref['tagsets'] : []);
         } else {
             $this->mongoCursor->setReadPreference(\MongoClient::RP_PRIMARY);
         }

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -547,11 +547,6 @@ class Cursor implements CursorInterface
      */
     public function setMongoCursorSlaveOkay($ok)
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->mongoCursor->slaveOkay($ok);
-            return;
-        }
-
         /* MongoCursor::setReadPreference() may not exist until 1.4.0. Although
          * we could throw an exception here, it's more user-friendly to NOP.
          */

--- a/lib/Doctrine/MongoDB/Cursor.php
+++ b/lib/Doctrine/MongoDB/Cursor.php
@@ -547,13 +547,6 @@ class Cursor implements CursorInterface
      */
     public function setMongoCursorSlaveOkay($ok)
     {
-        /* MongoCursor::setReadPreference() may not exist until 1.4.0. Although
-         * we could throw an exception here, it's more user-friendly to NOP.
-         */
-        if (!method_exists($this->mongoCursor, 'setReadPreference')) {
-            return;
-        }
-
         if ($ok) {
             // Preserve existing tags for non-primary read preferences
             $readPref = $this->mongoCursor->getReadPreference();

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -371,10 +371,6 @@ class Database
      */
     public function getSlaveOkay()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            return $this->mongoDB->getSlaveOkay();
-        }
-
         $readPref = $this->getReadPreference();
 
         return \MongoClient::RP_PRIMARY !== $readPref['type'];
@@ -394,10 +390,6 @@ class Database
      */
     public function setSlaveOkay($ok = true)
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            return $this->mongoDB->setSlaveOkay($ok);
-        }
-
         $prevSlaveOkay = $this->getSlaveOkay();
 
         if ($ok) {
@@ -544,11 +536,7 @@ class Database
      */
     protected function doCreateCollection($name, array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.4.0', '>=')) {
-            $this->mongoDB->createCollection($name, $options);
-        } else {
-            $this->mongoDB->createCollection($name, $options['capped'], $options['size'], $options['max']);
-        }
+        $this->mongoDB->createCollection($name, $options);
 
         return $this->doSelectCollection($name);
     }
@@ -623,10 +611,6 @@ class Database
      */
     protected function convertSocketTimeout(array $options)
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            return $options;
-        }
-
         if (isset($options['timeout']) && ! isset($options['socketTimeoutMS'])) {
             $options['socketTimeoutMS'] = $options['timeout'];
             unset($options['timeout']);

--- a/lib/Doctrine/MongoDB/Database.php
+++ b/lib/Doctrine/MongoDB/Database.php
@@ -23,7 +23,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\Event\CreateCollectionEventArgs;
 use Doctrine\MongoDB\Event\EventArgs;
 use Doctrine\MongoDB\Event\MutableEventArgs;
-use Doctrine\MongoDB\Util\ReadPreference;
 
 /**
  * Wrapper for the MongoDB class.
@@ -338,7 +337,7 @@ class Database
      */
     public function getReadPreference()
     {
-        return ReadPreference::convertReadPreference($this->mongoDB->getReadPreference());
+        return $this->mongoDB->getReadPreference();
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Util/ReadPreference.php
+++ b/lib/Doctrine/MongoDB/Util/ReadPreference.php
@@ -28,6 +28,7 @@ namespace Doctrine\MongoDB\Util;
  *
  * @since  1.0
  * @author Jeremy Mikola <jmikola@gmail.com>
+ * @deprecated 1.3 No longer required; will be removed for 2.0
  */
 final class ReadPreference
 {

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -503,8 +503,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $mongoCollection->expects($this->exactly(2))
             ->method('getReadPreference')
             ->will($this->returnValue(array(
-                'type' => 0,
-                'type_string' => 'primary',
+                'type' => \MongoClient::RP_PRIMARY,
             )));
 
         $mongoCollection->expects($this->once())
@@ -523,9 +522,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $mongoCollection->expects($this->exactly(2))
             ->method('getReadPreference')
             ->will($this->returnValue(array(
-                'type' => 1,
-                'type_string' => 'primary preferred',
-                'tagsets' => array(array('dc:east')),
+                'type' => \MongoClient::RP_PRIMARY_PREFERRED,
+                'tagsets' => array(array('dc' => 'east')),
             )));
 
         $mongoCollection->expects($this->once())

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -518,35 +518,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::collectionName, $coll->getName());
     }
 
-    public function testGetSetSlaveOkay()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $mongoCollection = $this->getMockMongoCollection();
-
-        $mongoCollection->expects($this->once())
-            ->method('getSlaveOkay')
-            ->will($this->returnValue(false));
-
-        $mongoCollection->expects($this->once())
-            ->method('setSlaveOkay')
-            ->with(true)
-            ->will($this->returnValue(false));
-
-        $collection = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
-
-        $this->assertEquals(false, $collection->getSlaveOkay());
-        $this->assertEquals(false, $collection->setSlaveOkay(true));
-    }
-
     public function testGetSetSlaveOkayReadPreferences()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
 
         $mongoCollection->expects($this->never())->method('getSlaveOkay');
@@ -570,10 +543,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSlaveOkayPreservesReadPreferenceTags()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
 
         $mongoCollection->expects($this->exactly(2))
@@ -596,10 +565,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testSetReadPreference()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
 
         $mongoCollection->expects($this->at(0))
@@ -996,10 +961,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testWriteConcernOptionIsConverted()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
@@ -1011,29 +972,8 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $coll->insert($document, array('safe' => true));
     }
 
-    public function testWriteConcernOptionIsNotConvertedForOlderDrivers()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $mongoCollection = $this->getMockMongoCollection();
-        $mongoCollection->expects($this->once())
-            ->method('insert')
-            ->with(array('x' => 1), array('safe' => true));
-
-        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
-
-        $document = array('x' => 1);
-        $coll->insert($document, array('safe' => true));
-    }
-
     public function testSocketTimeoutOptionIsConverted()
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
@@ -1045,50 +985,12 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $coll->insert($document, array('timeout' => 1000));
     }
 
-    public function testSocketTimeoutOptionIsNotConvertedForOlderDrivers()
-    {
-        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.5.0');
-        }
-
-        $mongoCollection = $this->getMockMongoCollection();
-        $mongoCollection->expects($this->once())
-            ->method('insert')
-            ->with(array('x' => 1), array('timeout' => 1000));
-
-        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
-
-        $document = array('x' => 1);
-        $coll->insert($document, array('timeout' => 1000));
-    }
-
     public function testWriteTimeoutOptionIsConverted()
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
         $mongoCollection = $this->getMockMongoCollection();
         $mongoCollection->expects($this->once())
             ->method('insert')
             ->with(array('x' => 1), array('wTimeoutMS' => 1000));
-
-        $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
-
-        $document = array('x' => 1);
-        $coll->insert($document, array('wtimeout' => 1000));
-    }
-
-    public function testWriteTimeoutOptionIsNotConvertedForOlderDrivers()
-    {
-        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.5.0');
-        }
-
-        $mongoCollection = $this->getMockMongoCollection();
-        $mongoCollection->expects($this->once())
-            ->method('insert')
-            ->with(array('x' => 1), array('wtimeout' => 1000));
 
         $coll = $this->getTestCollection($this->getMockDatabase(), $mongoCollection);
 

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -93,10 +93,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOption()
     {
-        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
-        }
-
         $pipeline = array(
             array('$match' => array('_id' => 'bar')),
             array('$project' => array('_id' => 1)),
@@ -119,10 +115,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOptionAndBatchSize()
     {
-        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
-        }
-
         $pipeline = array(
             array('$match' => array('_id' => 'bar')),
             array('$project' => array('_id' => 1)),
@@ -145,10 +137,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testAggregateWithCursorOptionAndTimeout()
     {
-        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
-        }
-
         if ( ! method_exists('MongoCommandCursor', 'timeout')) {
             $this->markTestSkipped('This test is not applicable to drivers without MongoCommandCursor::timeout()');
         }
@@ -175,19 +163,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Doctrine\MongoDB\CommandCursor', $result);
         $this->assertSame($mongoCommandCursor, $result->getMongoCommandCursor());
-    }
-
-    /**
-     * @expectedException \BadMethodCallException
-     */
-    public function testAggregateWithCursorOptionShouldThrowExceptionForOldDrivers()
-    {
-        if (method_exists('MongoCollection', 'aggregateCursor')) {
-            $this->markTestSkipped('This test is not applicable to drivers with MongoCollection::aggregateCursor()');
-        }
-
-        $coll = $this->getTestCollection();
-        $coll->aggregate(array(array('$limit' => 1)), array('cursor' => true));
     }
 
     /**
@@ -1021,10 +996,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testParallelCollectionScan()
     {
-        if ( ! method_exists('MongoCollection', 'parallelCollectionScan')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::parallelCollectionScan()');
-        }
-
         $numCursors = 3;
         $mongoCommandCursors = array(
             $this->getMockMongoCommandCursor(),

--- a/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CommandCursorFunctionalTest.php
@@ -11,10 +11,6 @@ class CommandCursorFunctionalTest extends BaseTest
     {
         parent::setUp();
 
-        if ( ! method_exists('MongoCollection', 'aggregateCursor')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCollection::aggregateCursor()');
-        }
-
         if (version_compare($this->getServerVersion(), '2.6.0', '<')) {
             $this->markTestSkipped('This test is not applicable to server versions < 2.6.0');
         }

--- a/tests/Doctrine/MongoDB/Tests/ConnectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/ConnectionTest.php
@@ -8,24 +8,10 @@ use Mongo;
 
 class ConnectionTest extends PHPUnit_Framework_TestCase
 {
-    public function testInitializeMongo()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $conn = new Connection();
-        $this->assertInstanceOf('Mongo', $conn->getMongo());
-    }
-
     public function testInitializeMongoClient()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $conn = new Connection();
-        $this->assertInstanceOf('MongoClient', $conn->getMongo());
+        $this->assertInstanceOf('MongoClient', $conn->getMongoClient());
     }
 
     public function testLog()
@@ -45,36 +31,6 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
         $conn->log(array('test'));
 
         $this->assertNull($conn->getConfiguration()->getLoggerCallable());
-    }
-
-    public function testSetMongo()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $mongo = $this->getMockBuilder('Mongo')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $conn = new Connection();
-        $conn->setMongo($mongo);
-        $this->assertSame($mongo, $conn->getMongo());
-    }
-
-    public function testSetMongoClient()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
-        $mongoClient = $this->getMockBuilder('MongoClient')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $conn = new Connection();
-        $conn->setMongo($mongoClient);
-        $this->assertSame($mongoClient, $conn->getMongo());
     }
 
     /**
@@ -173,10 +129,6 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     public function testSetReadPreference()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoClient = $this->getMockMongoClient();
 
         $mongoClient->expects($this->at(0))
@@ -208,10 +160,6 @@ class ConnectionTest extends PHPUnit_Framework_TestCase
 
     public function testConnectTimeoutOptionIsConverted()
     {
-        if (version_compare(phpversion('mongo'), '1.4.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.4.0');
-        }
-
         /* Since initialize() creates MongoClient directly, we cannot examine
          * the options passed to its constructor.
          *

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -133,34 +133,8 @@ class CursorTest extends BaseTest
         $this->assertEquals(array($this->doc1, $this->doc2, $this->doc3), $this->cursor->toArray(false));
     }
 
-    public function testSlaveOkay()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $mongoCursor = $this->getMockMongoCursor();
-
-        $mongoCursor->expects($this->at(0))
-            ->method('slaveOkay')
-            ->with(true);
-
-        $mongoCursor->expects($this->at(1))
-            ->method('slaveOkay')
-            ->with(false);
-
-        $cursor = $this->getTestCursor($this->getMockCollection(), $mongoCursor);
-
-        $cursor->slaveOkay(true);
-        $cursor->slaveOkay(false);
-    }
-
     public function testSlaveOkayNoopWithoutReadPreferences()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         if (method_exists('MongoCursor', 'setReadPreference')) {
             $this->markTestSkipped('This test is not applicable to drivers with MongoCursor::setReadPreference()');
         }

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -133,32 +133,8 @@ class CursorTest extends BaseTest
         $this->assertEquals(array($this->doc1, $this->doc2, $this->doc3), $this->cursor->toArray(false));
     }
 
-    public function testSlaveOkayNoopWithoutReadPreferences()
-    {
-        if (method_exists('MongoCursor', 'setReadPreference')) {
-            $this->markTestSkipped('This test is not applicable to drivers with MongoCursor::setReadPreference()');
-        }
-
-        $mongoCursor = $this->getMockMongoCursor();
-
-        $mongoCursor->expects($this->never())
-            ->method('slaveOkay');
-
-        $mongoCursor->expects($this->never())
-            ->method('setReadPreference');
-
-        $cursor = $this->getTestCursor($this->getMockCollection(), $mongoCursor);
-
-        $cursor->slaveOkay(true);
-        $cursor->slaveOkay(false);
-    }
-
     public function testSlaveOkayReadPreferences()
     {
-        if (!method_exists('MongoCursor', 'setReadPreference')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCursor::setReadPreference()');
-        }
-
         $mongoCursor = $this->getMockMongoCursor();
 
         $mongoCursor->expects($this->never())->method('slaveOkay');
@@ -185,10 +161,6 @@ class CursorTest extends BaseTest
 
     public function testSlaveOkayPreservesReadPreferenceTags()
     {
-        if (!method_exists('MongoCursor', 'setReadPreference')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCursor::setReadPreference()');
-        }
-
         $mongoCursor = $this->getMockMongoCursor();
 
         $mongoCursor->expects($this->once())
@@ -210,10 +182,6 @@ class CursorTest extends BaseTest
 
     public function testSetReadPreference()
     {
-        if (!method_exists('MongoCursor', 'setReadPreference')) {
-            $this->markTestSkipped('This test is not applicable to drivers without MongoCursor::setReadPreference()');
-        }
-
         $mongoCursor = $this->getMockMongoCursor();
 
         $mongoCursor->expects($this->at(0))
@@ -269,10 +237,6 @@ class CursorTest extends BaseTest
 
     public function testRecreate()
     {
-        if (!method_exists('MongoCursor', 'setReadPreference')) {
-            $this->markTestSkipped('This test requires MongoCursor::setReadPreference()');
-        }
-
         $self = $this;
 
         $setCursorExpectations = function($mongoCursor) use ($self) {

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -92,8 +92,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $mongoDB->expects($this->exactly(2))
             ->method('getReadPreference')
             ->will($this->returnValue(array(
-                'type' => 0,
-                'type_string' => 'primary',
+                'type' => \MongoClient::RP_PRIMARY,
             )));
 
         $mongoDB->expects($this->once())
@@ -113,9 +112,8 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $mongoDB->expects($this->exactly(2))
             ->method('getReadPreference')
             ->will($this->returnValue(array(
-                'type' => 1,
-                'type_string' => 'primary preferred',
-                'tagsets' => array(array('dc:east')),
+                'type' => \MongoClient::RP_PRIMARY_PREFERRED,
+                'tagsets' => array(array('dc' => 'east')),
             )));
 
         $mongoDB->expects($this->once())

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -29,15 +29,9 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
     {
         $mongoDB = $this->getMockMongoDB();
 
-        if (version_compare(phpversion('mongo'), '1.4.0', '>=')) {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', array('capped' => true, 'size' => 10485760, 'max' => 0));
-        } else {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', true, 10485760, 0);
-        }
+        $mongoDB->expects($this->once())
+            ->method('createCollection')
+            ->with('foo', array('capped' => true, 'size' => 10485760, 'max' => 0));
 
         $mongoDB->expects($this->once())
             ->method('selectCollection')
@@ -54,15 +48,9 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
     {
         $mongoDB = $this->getMockMongoDB();
 
-        if (version_compare(phpversion('mongo'), '1.4.0', '>=')) {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', array('capped' => true, 'size' => 10485760, 'max' => 0, 'autoIndexId' => false,));
-        } else {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', true, 10485760, 0);
-        }
+        $mongoDB->expects($this->once())
+            ->method('createCollection')
+            ->with('foo', array('capped' => true, 'size' => 10485760, 'max' => 0, 'autoIndexId' => false,));
 
         $mongoDB->expects($this->once())
             ->method('selectCollection')
@@ -79,15 +67,9 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
     {
         $mongoDB = $this->getMockMongoDB();
 
-        if (version_compare(phpversion('mongo'), '1.4.0', '>=')) {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', array('capped' => false, 'size' => 0, 'max' => 0));
-        } else {
-            $mongoDB->expects($this->once())
-                ->method('createCollection')
-                ->with('foo', false, 0, 0);
-        }
+        $mongoDB->expects($this->once())
+            ->method('createCollection')
+            ->with('foo', array('capped' => false, 'size' => 0, 'max' => 0));
 
         $mongoDB->expects($this->once())
             ->method('selectCollection')
@@ -100,35 +82,8 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Doctrine\MongoDB\Collection', $collection);
     }
 
-    public function testGetSetSlaveOkay()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.3.0');
-        }
-
-        $mongoDB = $this->getMockMongoDB();
-
-        $mongoDB->expects($this->once())
-            ->method('getSlaveOkay')
-            ->will($this->returnValue(false));
-
-        $mongoDB->expects($this->once())
-            ->method('setSlaveOkay')
-            ->with(true)
-            ->will($this->returnValue(false));
-
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
-
-        $this->assertEquals(false, $database->getSlaveOkay());
-        $this->assertEquals(false, $database->setSlaveOkay(true));
-    }
-
     public function testGetSetSlaveOkayReadPreferences()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoDB = $this->getMockMongoDB();
 
         $mongoDB->expects($this->never())->method('getSlaveOkay');
@@ -153,10 +108,6 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
 
     public function testSetSlaveOkayPreservesReadPreferenceTags()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoDB = $this->getMockMongoDB();
 
         $mongoDB->expects($this->exactly(2))
@@ -179,10 +130,6 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
 
     public function testSetReadPreference()
     {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-
         $mongoDB = $this->getMockMongoDB();
 
         $mongoDB->expects($this->at(0))
@@ -203,30 +150,10 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
 
     public function testSocketTimeoutOptionIsConverted()
     {
-        if (version_compare(phpversion('mongo'), '1.5.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.5.0');
-        }
-
         $mongoDB = $this->getMockMongoDB();
         $mongoDB->expects($this->any())
             ->method('command')
             ->with(array('count' => 'foo'), array('socketTimeoutMS' => 1000));
-
-        $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
-
-        $database->command(array('count' => 'foo'), array('timeout' => 1000));
-    }
-
-    public function testSocketTimeoutOptionIsNotConvertedForOlderDrivers()
-    {
-        if (version_compare(phpversion('mongo'), '1.5.0', '>=')) {
-            $this->markTestSkipped('This test is not applicable to driver versions >= 1.5.0');
-        }
-
-        $mongoDB = $this->getMockMongoDB();
-        $mongoDB->expects($this->any())
-            ->method('command')
-            ->with(array('count' => 'foo'), array('timeout' => 1000));
 
         $database = new Database($this->getMockConnection(), $mongoDB, $this->getMockEventManager());
 

--- a/tests/Doctrine/MongoDB/Tests/Util/ReadPreferenceTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Util/ReadPreferenceTest.php
@@ -6,13 +6,6 @@ use Doctrine\MongoDB\Util\ReadPreference;
 
 class ReadPreferenceTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (version_compare(phpversion('mongo'), '1.3.0', '<')) {
-            $this->markTestSkipped('This test is not applicable to driver versions < 1.3.0');
-        }
-    }
-
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
PHP 5.3 is no longer supported while PHP 5.4 is getting security updates only, so the next minor version upgrade (1.3.0) will require PHP 5.5 or 5.6. Please note that currently PHP 7 is not supported.
While we're at it, the new version will also bump the minimum driver versions. Thus, the 1.2, 1.3 and 1.4 versions of the mongo driver will no longer be supported and 1.5.0 or newer will be required.