### PR TITLE
Add query operators introduced with MongoDB 3.2

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -217,6 +217,26 @@ class Builder
     }
 
     /**
+     * A boolean flag to enable or disable case sensitive search for $text
+     * criteria.
+     *
+     * This method must be called after text().
+     *
+     * @see Expr::caseSensitive()
+     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @param bool $caseSensitive
+     * @return self
+     * @throws BadMethodCallException if the query does not already have $text criteria
+     *
+     * @since 1.3
+     */
+    public function caseSensitive($caseSensitive)
+    {
+        $this->expr->caseSensitive($caseSensitive);
+        return $this;
+    }
+
+    /**
      * Associates a comment to any expression taking a query predicate.
      *
      * @see Expr::comment()
@@ -268,6 +288,26 @@ class Builder
     public function debug($name = null)
     {
         return $name !== null ? $this->query[$name] : $this->query;
+    }
+
+    /**
+     * A boolean flag to enable or disable diacritic sensitive search for $text
+     * criteria.
+     *
+     * This method must be called after text().
+     *
+     * @see Builder::diacriticSensitive()
+     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @param bool $diacriticSensitive
+     * @return self
+     * @throws BadMethodCallException if the query does not already have $text criteria
+     *
+     * @since 1.3
+     */
+    public function diacriticSensitive($diacriticSensitive)
+    {
+        $this->expr->diacriticSensitive($diacriticSensitive);
+        return $this;
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -203,6 +203,66 @@ class Builder
     }
 
     /**
+     * Matches documents where all of the bit positions given by the query are
+     * clear.
+     *
+     * @see Expr::bitsAllClear()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllClear/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAllClear($value)
+    {
+        $this->expr->bitsAllClear($value);
+        return $this;
+    }
+
+    /**
+     * Matches documents where all of the bit positions given by the query are
+     * set.
+     *
+     * @see Expr::bitsAllSet()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllSet/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAllSet($value)
+    {
+        $this->expr->bitsAllSet($value);
+        return $this;
+    }
+
+    /**
+     * Matches documents where any of the bit positions given by the query are
+     * clear.
+     *
+     * @see Expr::bitsAnyClear()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnyClear/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAnyClear($value)
+    {
+        $this->expr->bitsAnyClear($value);
+        return $this;
+    }
+
+    /**
+     * Matches documents where any of the bit positions given by the query are
+     * set.
+     *
+     * @see Expr::bitsAnySet()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnySet/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAnySet($value)
+    {
+        $this->expr->bitsAnySet($value);
+        return $this;
+    }
+
+    /**
      * Apply a bitwise xor operation on the current field.
      *
      * @see Expr::bitXor()

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -203,6 +203,66 @@ class Expr
     }
 
     /**
+     * Matches documents where all of the bit positions given by the query are
+     * clear.
+     *
+     * @see Builder::bitsAllClear()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllClear/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAllClear($value)
+    {
+        $this->requiresCurrentField();
+        return $this->operator('$bitsAllClear', $value);
+    }
+
+    /**
+     * Matches documents where all of the bit positions given by the query are
+     * set.
+     *
+     * @see Builder::bitsAllSet()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAllSet/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAllSet($value)
+    {
+        $this->requiresCurrentField();
+        return $this->operator('$bitsAllSet', $value);
+    }
+
+    /**
+     * Matches documents where any of the bit positions given by the query are
+     * clear.
+     *
+     * @see Builder::bitsAnyClear()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnyClear/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAnyClear($value)
+    {
+        $this->requiresCurrentField();
+        return $this->operator('$bitsAnyClear', $value);
+    }
+
+    /**
+     * Matches documents where any of the bit positions given by the query are
+     * set.
+     *
+     * @see Builder::bitsAnySet()
+     * @see https://docs.mongodb.org/manual/reference/operator/query/bitsAnySet/
+     * @param int|array|\MongoBinData $value
+     * @return self
+     */
+    public function bitsAnySet($value)
+    {
+        $this->requiresCurrentField();
+        return $this->operator('$bitsAnySet', $value);
+    }
+
+    /**
      * Apply a bitwise xor operation on the current field.
      *
      * @see Builder::bitXor()

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -216,6 +216,36 @@ class Expr
     }
 
     /**
+     * A boolean flag to enable or disable case sensitive search for $text
+     * criteria.
+     *
+     * This method must be called after text().
+     *
+     * @see Builder::caseSensitive()
+     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @param bool $caseSensitive
+     * @return self
+     * @throws BadMethodCallException if the query does not already have $text criteria
+     *
+     * @since 1.3
+     */
+    public function caseSensitive($caseSensitive)
+    {
+        if ( ! isset($this->query['$text'])) {
+            throw new BadMethodCallException('This method requires a $text operator (call text() first)');
+        }
+
+        // Remove caseSensitive option to keep support for older database versions
+        if ($caseSensitive) {
+            $this->query['$text']['$caseSensitive'] = true;
+        } elseif (isset($this->query['$text']['$caseSensitive'])) {
+            unset($this->query['$text']['$caseSensitive']);
+        }
+
+        return $this;
+    }
+
+    /**
      * Associates a comment to any expression taking a query predicate.
      *
      * @see Builder::comment()
@@ -246,6 +276,36 @@ class Expr
 
         $this->requiresCurrentField();
         $this->newObj['$currentDate'][$this->currentField]['$type'] = $type;
+        return $this;
+    }
+
+    /**
+     * A boolean flag to enable or disable diacritic sensitive search for $text
+     * criteria.
+     *
+     * This method must be called after text().
+     *
+     * @see Builder::diacriticSensitive()
+     * @see http://docs.mongodb.org/manual/reference/operator/text/
+     * @param bool $diacriticSensitive
+     * @return self
+     * @throws BadMethodCallException if the query does not already have $text criteria
+     *
+     * @since 1.3
+     */
+    public function diacriticSensitive($diacriticSensitive)
+    {
+        if ( ! isset($this->query['$text'])) {
+            throw new BadMethodCallException('This method requires a $text operator (call text() first)');
+        }
+
+        // Remove diacriticSensitive option to keep support for older database versions
+        if ($diacriticSensitive) {
+            $this->query['$text']['$diacriticSensitive'] = true;
+        } elseif (isset($this->query['$text']['$diacriticSensitive'])) {
+            unset($this->query['$text']['$diacriticSensitive']);
+        }
+
         return $this;
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -396,7 +396,11 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'text()' => array('text', array('foo')),
             'max()' => array('max', array(1)),
             'min()' => array('min', array(1)),
-            'comment()' => array('comment', array('A comment explaining what the query does'))
+            'comment()' => array('comment', array('A comment explaining what the query does')),
+            'bitsAllClear()' => array('bitsAllClear', array(5)),
+            'bitsAllSet()' => array('bitsAllSet', array(5)),
+            'bitsAnyClear()' => array('bitsAnyClear', array(5)),
+            'bitsAnySet()' => array('bitsAnySet', array(5)),
         );
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/BuilderTest.php
@@ -391,6 +391,8 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
             'elemMatch() Expr' => array('elemMatch', array($this->getMockExpr())),
             'not()' => array('not', array($this->getMockExpr())),
             'language()' => array('language', array('en')),
+            'caseSensitive()' => array('caseSensitive', array(true)),
+            'diacriticSensitive()' => array('diacriticSensitive', array(true)),
             'text()' => array('text', array('foo')),
             'max()' => array('max', array(1)),
             'min()' => array('min', array(1)),

--- a/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/ExprTest.php
@@ -50,6 +50,62 @@ class ExprTest extends \PHPUnit_Framework_TestCase
         $expr->language('en');
     }
 
+    public function testCaseSensitiveWithText()
+    {
+        $expr = new Expr();
+        $expr->text('foo');
+
+        $this->assertSame($expr, $expr->caseSensitive(true));
+        $this->assertEquals(array('$text' => array('$search' => 'foo', '$caseSensitive' => true)), $expr->getQuery());
+    }
+
+    public function testCaseSensitiveFalseRemovesOption()
+    {
+        $expr = new Expr();
+        $expr->text('foo');
+
+        $expr->caseSensitive(true);
+        $expr->caseSensitive(false);
+        $this->assertEquals(array('$text' => array('$search' => 'foo')), $expr->getQuery());
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testCaseSensitiveRequiresTextOperator()
+    {
+        $expr = new Expr();
+        $expr->caseSensitive('en');
+    }
+
+    public function testDiacriticSensitiveWithText()
+    {
+        $expr = new Expr();
+        $expr->text('foo');
+
+        $this->assertSame($expr, $expr->diacriticSensitive(true));
+        $this->assertEquals(array('$text' => array('$search' => 'foo', '$diacriticSensitive' => true)), $expr->getQuery());
+    }
+
+    public function testDiacriticSensitiveFalseRemovesOption()
+    {
+        $expr = new Expr();
+        $expr->text('foo');
+
+        $expr->diacriticSensitive(true);
+        $expr->diacriticSensitive(false);
+        $this->assertEquals(array('$text' => array('$search' => 'foo')), $expr->getQuery());
+    }
+
+    /**
+     * @expectedException BadMethodCallException
+     */
+    public function testDiacriticSensitiveRequiresTextOperator()
+    {
+        $expr = new Expr();
+        $expr->diacriticSensitive('en');
+    }
+
     public function testOperatorWithCurrentField()
     {
         $expr = new Expr();


### PR DESCRIPTION
This PR adds the $caseSensitive and $diacriticInsensitive options to $text queries as well as the following operators:
* $bitsAllClear
* $bitsAllSet
* $bitsAnyClear
* $bitsAnySet