### PR TITLE
Feature proposal: Add hooks around fetch single result from curosr

### DIFF
--- a/lib/Doctrine/MongoDB/Collection.php
+++ b/lib/Doctrine/MongoDB/Collection.php
@@ -1511,4 +1511,13 @@ class Collection
             array_intersect_key($options, $keys),
         );
     }
+
+    /**
+     * Return the EventManager attached to this collection.
+     *
+     * @return EventManager
+     */
+    public function getEventManager() {
+        return $this->eventManager;
+    }
 }

--- a/lib/Doctrine/MongoDB/Event/FetchSingleResultFromCursorEventArgs.php
+++ b/lib/Doctrine/MongoDB/Event/FetchSingleResultFromCursorEventArgs.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+*/
+
+namespace Doctrine\MongoDB\Event;
+
+use Doctrine\Common\EventArgs as BaseEventArgs;
+
+/**
+ * Event args for fetch one from cursor queries.
+ *
+ * @since  1.0
+ * @author Jonathan Block <block.jon@gmail.com>
+ */
+class FetchSingleResultFromCursorEventArgs extends BaseEventArgs
+{
+    private $invoker;
+    private $query;
+    private $fields;
+
+    /**
+     * Constructor.
+     *
+     * @param object $invoker
+     */
+    public function __construct($invoker, $query, $fields)
+    {
+        $this->invoker = $invoker;
+        $this->query = $query;
+        $this->fields = $fields;
+    }
+
+    public function getInvoker()
+    {
+        return $this->invoker;
+    }
+
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    public function getFields()
+    {
+        return $this->fields;
+    }
+}

--- a/lib/Doctrine/MongoDB/Events.php
+++ b/lib/Doctrine/MongoDB/Events.php
@@ -52,6 +52,9 @@ final class Events
     const preDropDatabase = 'preDropDatabase';
     const postDropDatabase = 'postDropDatabase';
 
+    const preFetchSingleResultFromCursor = 'preFetchSingleResultFromCursor';
+    const postFetchSingleResultFromCursor = 'postFetchSingleResultFromCursor';
+
     const preFind = 'collectionPreFind';
     const postFind = 'collectionPostFind';
 


### PR DESCRIPTION
I'd like to track how long it takes to fetch an item across the db handle when I do a fetchSingleResult. Seems like this is a way to do it. Seeking comment.