### PR TITLE
Update documentation link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,6 @@ To run the tests:
 ## More resources:
 
 * [Website](http://www.doctrine-project.org)
-* [Documentation](http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/index.html)
+* [Documentation](http://www.doctrine-project.org/projects/mongodb.html)
 * [Issue Tracker](https://github.com/doctrine/mongodb/issues)
 * [Releases](https://github.com/doctrine/mongodb/releases)


### PR DESCRIPTION
The "Documentation" link in the READMEs for both these:

 * https://github.com/doctrine/mongodb
 * https://github.com/doctrine/mongodb-odm

Point to:

 * http://docs.doctrine-project.org/projects/doctrine-mongodb-odm/en/latest/index.html

The former should probably link somewhere else to avoid confusion between the two projects. 

Is http://www.doctrine-project.org/projects/mongodb.html the correct one for this project?