### PR TITLE
Add expr method to aggregation expression object

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Expr.php
@@ -409,6 +409,18 @@ class Expr
     }
 
     /**
+     * Returns a new expression object
+     *
+     * @return static
+     *
+     * @since 1.3
+     */
+    public function expr()
+    {
+        return new static();
+    }
+
+    /**
      * Allows any expression to be used as a field value.
      *
      * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/ExprTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/ExprTest.php
@@ -164,6 +164,15 @@ class ExprTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('$exp' => '$field'), $expr->getExpression());
     }
 
+    public function testExpr()
+    {
+        $expr = new Expr();
+
+        $newExpr = $expr->expr();
+        $this->assertInstanceOf(Expr::class, $newExpr);
+        $this->assertNotSame($newExpr, $expr);
+    }
+
     public function testExpression()
     {
         $nestedExpr = new Expr();


### PR DESCRIPTION
This adds the `expr()` method to the expression object the same way it is already available in the builder. This is helpful when needing to create a fresh expression object (to be nested inside) without having access to the actual aggregation builder.

This may be confusing due to the similarity to the `expression()` method that already exists (which can be used to apply an expression previously created with `expr()`) but I can't come up with any more meaningful name.