### PR TITLE
Allow using operators in group stages

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Group.php
@@ -29,23 +29,8 @@ use Doctrine\MongoDB\Aggregation\Stage;
  * @author alcaeus <alcaeus@alcaeus.org>
  * @since 1.2
  */
-class Group extends Stage
+class Group extends Operator
 {
-    /**
-     * @var Expr
-     */
-    protected $expr;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct(Builder $builder)
-    {
-        $this->expr = new Expr();
-
-        parent::__construct($builder);
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -74,4 +74,16 @@ class GroupTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array(array('$group' => array('_id' => '$field', 'count' => array('$sum' => 1)))), $builder->getPipeline());
     }
+
+    public function testGroupWithOperatorInId()
+    {
+        $groupStage = new Group($this->getTestAggregationBuilder());
+        $groupStage
+            ->field('_id')
+            ->year('$dateField')
+            ->field('count')
+            ->sum(1);
+
+        $this->assertSame(array('$group' => array('_id' => ['$year' => '$dateField'], 'count' => array('$sum' => 1))), $groupStage->getExpression());
+    }
 }


### PR DESCRIPTION
Fixes #254.

This change allows users to use operators in group stages for the ID field:
```
$builder
    ->group()
        ->field('_id')
        ->year('$dateField')
        ->field('count')
        ->sum(1);
```

Note: this will also allow building the following pipeline which is invalid and will error out on MongoDB when executed:
```
$builder
    ->group()
        ->field('_id')
        ->year('$dateField')
        ->field('month')
        ->month('$dateField');
```

I've decided against checking for this as this would require overwriting all operators declared in the `Operator` class to check whether the current field is an ID field and error out if it's not. People familiar with aggregation queries should be able to make this distinction on their own.