### PR TITLE
Initialize the aggregation builder stages property with an empty array

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -41,7 +41,7 @@ class Builder
     /**
      * @var Stage[]
      */
-    private $stages;
+    private $stages = array();
 
     /**
      * Create a new aggregation builder.


### PR DESCRIPTION
This will fix a PHP warning when calling `getPipeline()` on an Aggregation
builder without any stages since array_map expects an array as second argument, but the `$stages`
property is still `null`. The new behaviour is consistent with the Query builder, which also
returns an empty array.