### PR TITLE
Drop support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         { "name": "Andreas Braun", "email": "alcaeus@alcaeus.org" }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "ext-mongo": "^1.5",
         "doctrine/common": "^2.2"
     },


### PR DESCRIPTION
Since PHP 5.5 won't be supported after 10 July 2016, the upcoming 1.4 release will require PHP 5.6 (and PHP 7.0 using a polyfill).