### PR TITLE
Removed unused use statements

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Group.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Group.php
@@ -19,7 +19,6 @@
 
 namespace Doctrine\MongoDB\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Expr;
 use Doctrine\MongoDB\Aggregation\Stage;
 

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -20,7 +20,6 @@
 namespace Doctrine\MongoDB\Query;
 
 use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Database;
 use GeoJson\Geometry\Geometry;
 use GeoJson\Geometry\Point;
 use BadMethodCallException;

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GeoNearTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\GeoNear;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GroupTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GroupTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Expr;
 use Doctrine\MongoDB\Aggregation\Stage\Group;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/IndexStatsTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\IndexStats;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/LimitTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/LimitTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Limit;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/LookupTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/LookupTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Lookup;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/MatchTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/MatchTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Match;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/OperatorTest.php
@@ -2,9 +2,7 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Expr;
-use Doctrine\MongoDB\Aggregation\Stage\Match;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 
 class OperatorTest extends \PHPUnit_Framework_TestCase

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/OutTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/OutTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Out;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Expr;
 use Doctrine\MongoDB\Aggregation\Stage\Project;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/RedactTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/RedactTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Redact;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Sample;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SkipTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SkipTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Skip;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SortTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SortTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Sort;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/UnwindTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
 
-use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage\Unwind;
 use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
 

--- a/tests/Doctrine/MongoDB/Tests/CollectionTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CollectionTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\MongoDB\Tests;
 use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\ArrayIterator;
 use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Database;
 use Doctrine\MongoDB\Tests\Constraint\ArrayHasKeyAndValue;
 use MongoCollection;

--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -3,7 +3,6 @@
 namespace Doctrine\MongoDB\Tests;
 
 use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Connection;
 use Doctrine\MongoDB\Cursor;
 
 class CursorTest extends BaseTest

--- a/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
+++ b/tests/Doctrine/MongoDB/Tests/DatabaseTest.php
@@ -2,11 +2,7 @@
 
 namespace Doctrine\MongoDB\Tests;
 
-use Doctrine\MongoDB\Collection;
-use Doctrine\MongoDB\Connection;
-use Doctrine\MongoDB\LoggableCollection;
 use Doctrine\MongoDB\Database;
-use Doctrine\Common\EventManager;
 
 class DatabaseTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Doctrine/MongoDB/Tests/EventTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EventTest.php
@@ -5,7 +5,6 @@ namespace Doctrine\MongoDB\Tests;
 use Doctrine\MongoDB\Connection;
 use Doctrine\Common\EventManager;
 use PHPUnit_Framework_TestCase;
-use Mongo;
 
 class EventTest extends PHPUnit_Framework_TestCase
 {

--- a/tests/Doctrine/MongoDB/Tests/LoggableCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/LoggableCursorTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests;
 
-use Doctrine\MongoDB\LoggableCursor;
 
 class LoggableCursorTest extends BaseTest
 {

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -2,7 +2,6 @@
 namespace Doctrine\MongoDB\Tests\Query;
 
 use Doctrine\MongoDB\Query\Query;
-use Doctrine\MongoDB\Tests\Constraint\ArrayHasKeyAndValue;
 
 class QueryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Doctrine/MongoDB/Tests/RetryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/RetryTest.php
@@ -2,7 +2,6 @@
 
 namespace Doctrine\MongoDB\Tests;
 
-use PHPUnit_Framework_TestCase;
 use Doctrine\MongoDB\Collection;
 use Doctrine\MongoDB\Configuration;
 use Doctrine\MongoDB\Connection;


### PR DESCRIPTION
`grep` result revealed those unused uses while searching on this lib.
So I've corrected it using http://cs.sensiolabs.org/ tool.

Even though it isn't really important, less is better I think. :)