### PR TITLE
Pass query options when running count command

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -275,8 +275,11 @@ class Query implements IteratorAggregate
                 $collection = $this->collection;
                 $query = $this->query;
 
-                $closure = function() use ($collection, $query) {
-                    return $collection->count($query['query']);
+                $closure = function() use ($collection, $query, $options) {
+                    return $collection->count(
+                        $query['query'],
+                        array_merge($options, $this->getQueryOptions('hint', 'limit', 'maxTimeMS', 'skip'))
+                    );
                 };
 
                 return $this->withReadPreference($collection, $closure);

--- a/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Query/QueryTest.php
@@ -235,6 +235,27 @@ class QueryTest extends \PHPUnit_Framework_TestCase
         $query->execute();
     }
 
+    public function testCountWithOptions()
+    {
+        $collection = $this->getMockCollection();
+
+        $collection->expects($this->at(0))
+            ->method('count')
+            ->with(['foo' => 'bar'], ['skip' => 5, 'maxTimeMS' => 10])
+            ->will($this->returnValue(100));
+
+        $queryArray = [
+            'type' => Query::TYPE_COUNT,
+            'query' => ['foo' => 'bar'],
+            'skip' => 5,
+            'maxTimeMS' => 10,
+        ];
+
+        $query = new Query($collection, $queryArray, []);
+
+        $this->assertSame(100, $query->execute());
+    }
+
     public function testEagerCursorPreparation()
     {
         $cursor = $this->getMockCursor();


### PR DESCRIPTION
Fixes #267.

This allows the user to pass in hint, limit, maxTimeMS and skip options when running count queries.