### PR TITLE
Allow passing multiple arguments to add* methods

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Expr.php
@@ -78,37 +78,37 @@ class Expr
     }
 
     /**
-     * Add an $and clause to the current expression.
+     * Adds one or more $and clauses to the current expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/and/
      * @param array|self $expression
      * @return $this
      */
-    public function addAnd($expression)
+    public function addAnd($expression /*, $expression2, ... */)
     {
-        if ($this->currentField) {
-            $this->expr[$this->currentField]['$and'][] = $this->ensureArray($expression);
-        } else {
-            $this->expr['$and'][] = $this->ensureArray($expression);
+        if (! isset($this->expr['$and'])) {
+            $this->expr['$and'] = [];
         }
+
+        $this->expr['$and'] = array_merge($this->expr['$and'], array_map([$this, 'ensureArray'], func_get_args()));
 
         return $this;
     }
 
     /**
-     * Add an $or clause to the current expression.
+     * Adds one or more $or clause to the current expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/or/
      * @param array|self $expression
      * @return $this
      */
-    public function addOr($expression)
+    public function addOr($expression /*, $expression2, ... */)
     {
-        if ($this->currentField) {
-            $this->expr[$this->currentField]['$or'][] = $this->ensureArray($expression);
-        } else {
-            $this->expr['$or'][] = $this->ensureArray($expression);
+        if (! isset($this->expr['$or'])) {
+            $this->expr['$or'] = [];
         }
+
+        $this->expr['$or'] = array_merge($this->expr['$or'], array_map([$this, 'ensureArray'], func_get_args()));
 
         return $this;
     }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Match.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Match.php
@@ -58,7 +58,7 @@ class Match extends Stage
     }
 
     /**
-     * Add an $and clause to the current query.
+     * Add one or more $and clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::matchExpr()}
      * method.
@@ -68,15 +68,15 @@ class Match extends Stage
      * @param array|Expr $expression
      * @return $this
      */
-    public function addAnd($expression)
+    public function addAnd($expression /* , $expression2, ... */)
     {
-        $this->query->addAnd($expression);
+        $this->query->addAnd(...func_get_args());
 
         return $this;
     }
 
     /**
-     * Add a $nor clause to the current query.
+     * Add one or more $nor clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::matchExpr()}
      * method.
@@ -86,15 +86,15 @@ class Match extends Stage
      * @param array|Expr $expression
      * @return $this
      */
-    public function addNor($expression)
+    public function addNor($expression /*, $expression2, ... */)
     {
-        $this->query->addNor($expression);
+        $this->query->addNor(...func_get_args());
 
         return $this;
     }
 
     /**
-     * Add an $or clause to the current query.
+     * Add one or more $or clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::matchExpr()}
      * method.
@@ -104,9 +104,9 @@ class Match extends Stage
      * @param array|Expr $expression
      * @return $this
      */
-    public function addOr($expression)
+    public function addOr($expression /* , $expression2, ... */)
     {
-        $this->query->addOr($expression);
+        $this->query->addOr(...func_get_args());
 
         return $this;
     }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Operator.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Operator.php
@@ -88,31 +88,31 @@ abstract class Operator extends Stage
     }
 
     /**
-     * Add an $and clause to the current expression.
+     * Add one or more $and clauses to the current expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/and/
      * @see Expr::addAnd
      * @param array|Expr $expression
      * @return $this
      */
-    public function addAnd($expression)
+    public function addAnd($expression /* , $expression2, ... */)
     {
-        $this->expr->addAnd($expression);
+        $this->expr->addAnd(...func_get_args());
 
         return $this;
     }
 
     /**
-     * Add an $or clause to the current expression.
+     * Add one or more $or clauses to the current expression.
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/or/
      * @see Expr::addOr
      * @param array|Expr $expression
      * @return $this
      */
-    public function addOr($expression)
+    public function addOr($expression /* , $expression2, ... */)
     {
-        $this->expr->addOr($expression);
+        $this->expr->addOr(...func_get_args());
 
         return $this;
     }

--- a/lib/Doctrine/MongoDB/Query/Builder.php
+++ b/lib/Doctrine/MongoDB/Query/Builder.php
@@ -68,7 +68,7 @@ class Builder
     }
 
     /**
-     * Add an $and clause to the current query.
+     * Add one or more $and clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::expr()} method.
      *
@@ -77,9 +77,9 @@ class Builder
      * @param array|Expr $expression
      * @return $this
      */
-    public function addAnd($expression)
+    public function addAnd($expression /* , $expression2, ... */)
     {
-        $this->expr->addAnd($expression);
+        $this->expr->addAnd(...func_get_args());
         return $this;
     }
 
@@ -105,7 +105,7 @@ class Builder
     }
 
     /**
-     * Add a $nor clause to the current query.
+     * Add one or more $nor clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::expr()} method.
      *
@@ -114,14 +114,14 @@ class Builder
      * @param array|Expr $expression
      * @return $this
      */
-    public function addNor($expression)
+    public function addNor($expression /* , $expression2, ... */)
     {
-        $this->expr->addNor($expression);
+        $this->expr->addNor(...func_get_args());
         return $this;
     }
 
     /**
-     * Add an $or clause to the current query.
+     * Add one or more $or clauses to the current query.
      *
      * You can create a new expression using the {@link Builder::expr()} method.
      *
@@ -130,9 +130,9 @@ class Builder
      * @param array|Expr $expression
      * @return $this
      */
-    public function addOr($expression)
+    public function addOr($expression /* , $expression2, ... */)
     {
-        $this->expr->addOr($expression);
+        $this->expr->addOr(...func_get_args());
         return $this;
     }
 

--- a/lib/Doctrine/MongoDB/Query/Expr.php
+++ b/lib/Doctrine/MongoDB/Query/Expr.php
@@ -57,16 +57,29 @@ class Expr
     protected $currentField;
 
     /**
-     * Add an $and clause to the current query.
+     * Add one or more $and clauses to the current query.
      *
      * @see Builder::addAnd()
      * @see http://docs.mongodb.org/manual/reference/operator/and/
      * @param array|Expr $expression
      * @return $this
      */
-    public function addAnd($expression)
+    public function addAnd($expression /*, $expression2, ... */)
     {
-        $this->query['$and'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        if (! isset($this->query['$and'])) {
+            $this->query['$and'] = [];
+        }
+
+        $this->query['$and'] = array_merge(
+            $this->query['$and'],
+            array_map(
+                function ($expression) {
+                    return $expression instanceof Expr ? $expression->getQuery() : $expression;
+                },
+                func_get_args()
+            )
+        );
+
         return $this;
     }
 
@@ -93,30 +106,46 @@ class Expr
     }
 
     /**
-     * Add a $nor clause to the current query.
+     * Add one or more $nor clauses to the current query.
      *
      * @see Builder::addNor()
      * @see http://docs.mongodb.org/manual/reference/operator/nor/
      * @param array|Expr $expression
      * @return $this
      */
-    public function addNor($expression)
+    public function addNor($expression /* , $expression2, ... */)
     {
-        $this->query['$nor'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        if (! isset($this->query['$nor'])) {
+            $this->query['$nor'] = [];
+        }
+
+        $this->query['$nor'] = array_merge(
+            $this->query['$nor'],
+            array_map(function ($expression) { return $expression instanceof Expr ? $expression->getQuery() : $expression; }, func_get_args())
+        );
+
         return $this;
     }
 
     /**
-     * Add an $or clause to the current query.
+     * Add one or more $or clauses to the current query.
      *
      * @see Builder::addOr()
      * @see http://docs.mongodb.org/manual/reference/operator/or/
      * @param array|Expr $expression
      * @return $this
      */
-    public function addOr($expression)
+    public function addOr($expression /* , $expression2, ... */)
     {
-        $this->query['$or'][] = $expression instanceof Expr ? $expression->getQuery() : $expression;
+        if (! isset($this->query['$or'])) {
+            $this->query['$or'] = [];
+        }
+
+        $this->query['$or'] = array_merge(
+            $this->query['$or'],
+            array_map(function ($expression) { return $expression instanceof Expr ? $expression->getQuery() : $expression; }, func_get_args())
+        );
+
         return $this;
     }
 


### PR DESCRIPTION
Fixes #262.

This allows passing multiple expressions to the `addAnd`, `addNor` and `addOr` methods in the query builder as well as the `addAnd` and `addOr` methods in the aggregation builder.