### PR TITLE
Fixed  sample stage

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Sample.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Sample.php
@@ -52,7 +52,7 @@ class Sample extends Stage
     public function getExpression()
     {
         return [
-            '$sample' => $this->size
+            '$sample' => ['size' => $this->size]
         ];
     }
 }

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/BuilderTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/BuilderTest.php
@@ -32,7 +32,7 @@ class BuilderTest extends \PHPUnit_Framework_TestCase
                     'group' => ['$in' => ['a', 'b']]
                 ]
             ],
-            ['$sample' => 10],
+            ['$sample' => ['size' => 10]],
             ['$lookup' =>
                 [
                     'from' => 'orders',

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SampleTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SampleTest.php
@@ -13,7 +13,7 @@ class SampleTest extends \PHPUnit_Framework_TestCase
     {
         $sampleStage = new Sample($this->getTestAggregationBuilder(), 10);
 
-        $this->assertSame(['$sample' => 10], $sampleStage->getExpression());
+        $this->assertSame(['$sample' => ['size' => 10]], $sampleStage->getExpression());
     }
 
     public function testSampleFromBuilder()
@@ -21,6 +21,6 @@ class SampleTest extends \PHPUnit_Framework_TestCase
         $builder = $this->getTestAggregationBuilder();
         $builder->sample(10);
 
-        $this->assertSame([['$sample' => 10]], $builder->getPipeline());
+        $this->assertSame([['$sample' => ['size' => 10]]], $builder->getPipeline());
     }
 }


### PR DESCRIPTION
Added  'size'  attribute to the sample stage for query builder
With reference to the offical mongodb documentation

{ $sample: { size: <positive integer> } }