### PR TITLE
Add $addFields operator to AggregationBuilder

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -55,6 +55,26 @@ class Builder
     }
 
     /**
+     * Adds new fields to documents. $addFields outputs documents that contain all
+     * existing fields from the input documents and newly added fields.
+     *
+     * The $addFields stage is equivalent to a $project stage that explicitly specifies
+     * all existing fields in the input documents and adds the new fields.
+     *
+     * If the name of the new field is the same as an existing field name (including _id),
+     * $addFields overwrites the existing value of that field with the value of the
+     * specified expression.
+     *
+     * @see http://docs.mongodb.com/manual/reference/operator/aggregation/addFields/
+     *
+     * @return Stage\AddFields
+     */
+    public function addFields()
+    {
+        return $this->addStage(new Stage\AddFields($this));
+    }
+
+    /**
      * @return Expr
      */
     public function expr()

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AddFields.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $addFields stage to an aggregation pipeline.
+ *
+ * @author Boris Guéry <guery.b@gmail.com>
+ */
+class AddFields extends Operator
+{
+    /**
+     * Assembles the aggregation stage
+     *
+     * @return array
+     */
+    public function getExpression()
+    {
+        return [
+            '$addFields' => $this->expr->getExpression()
+        ];
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/AddFieldsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\AddFields;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+
+class AddFieldsTest extends \PHPUnit_Framework_TestCase
+{
+    use AggregationTestCase;
+
+    public function testAddFieldsStage()
+    {
+        $addFieldsStage = new AddFields($this->getTestAggregationBuilder());
+        $addFieldsStage
+            ->field('product')
+            ->multiply('$field', 5);
+
+        $this->assertSame(['$addFields' => ['product' => ['$multiply' => ['$field', 5]]]], $addFieldsStage->getExpression());
+    }
+
+    public function testProjectFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder
+            ->addFields()
+            ->field('product')
+            ->multiply('$field', 5);
+
+        $this->assertSame([['$addFields' => ['product' => ['$multiply' => ['$field', 5]]]]], $builder->getPipeline());
+    }
+}


### PR DESCRIPTION
This PR adds the [`$addFields`](https://docs.mongodb.com/manual/reference/operator/aggregation/addFields/) operator which is new in MongoDB 3.4

