### PR TITLE
Add PHP 7 to matrix and fix build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   global:
@@ -13,8 +14,6 @@ env:
     - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
-  matrix:
-    - SERVER_VERSION="2.6"
     - SERVER_VERSION="3.2"
 
 matrix:
@@ -30,6 +29,7 @@ before_install:
 
 install:
   - sudo apt-get install mongodb-enterprise
+  - sleep 1
   - if ! nc -z localhost 27017; then sudo service mongod start; fi
 
 before_script:


### PR DESCRIPTION
This one tiny sleep hopefully fixes the build issues that we've been having. In addition to that, it's time to test against PHP 7.1. Unfortunately, adding `nightly` to the build fails due to segfaults when requiring mongo-php-adapter. Oh well.