### PR TITLE
Add support for aggregation pipeline stages added in MongoDB 3.4

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -94,6 +94,27 @@ class Builder
     }
 
     /**
+     * Categorizes incoming documents into a specific number of groups, called
+     * buckets, based on a specified expression.
+     *
+     * Bucket boundaries are automatically determined in an attempt to evenly
+     * distribute the documents into the specified number of buckets. Each
+     * bucket is represented as a document in the output. The document for each
+     * bucket contains an _id field, whose value specifies the inclusive lower
+     * bound and the exclusive upper bound for the bucket, and a count field
+     * that contains the number of documents in the bucket. The count field is
+     * included by default when the output is not specified.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/
+     *
+     * @return Stage\BucketAuto
+     */
+    public function bucketAuto()
+    {
+        return $this->addStage(new Stage\BucketAuto($this));
+    }
+
+    /**
      * @return Expr
      */
     public function expr()

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -197,6 +197,20 @@ class Builder
     }
 
     /**
+     * Performs a recursive search on a collection, with options for restricting
+     * the search by recursion depth and query filter.
+     *
+     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
+     *
+     * @param string $from
+     * @return Stage\GraphLookup
+     */
+    public function graphLookup($from)
+    {
+        return $this->addStage(new Stage\GraphLookup($this, $from));
+    }
+
+    /**
      * Groups documents by some specified expression and outputs to the next
      * stage a document for each distinct grouping.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -215,7 +215,8 @@ class Builder
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
      *
-     * @param string $from
+     * @param string $from Target collection for the $graphLookup operation to
+     * search, recursively matching the connectFromField to the connectToField.
      * @return Stage\GraphLookup
      */
     public function graphLookup($from)
@@ -348,7 +349,8 @@ class Builder
      * including the _id field. You can promote an existing embedded document to
      * the top level, or create a new document for promotion.
      *
-     * @param string $expression
+     * @param string|null $expression Optional. A replacement expression that
+     * resolves to a document.
      *
      * @return Stage\ReplaceRoot
      */

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -134,6 +134,20 @@ class Builder
     }
 
     /**
+     * Processes multiple aggregation pipelines within a single stage on the
+     * same set of input documents.
+     *
+     * Each sub-pipeline has its own field in the output document where its
+     * results are stored as an array of documents.
+     *
+     * @return Stage\Facet
+     */
+    public function facet()
+    {
+        return $this->addStage(new Stage\Facet($this));
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      *
      * A GeoJSON point may be provided as the first and only argument for

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -75,6 +75,25 @@ class Builder
     }
 
     /**
+     * Categorizes incoming documents into groups, called buckets, based on a
+     * specified expression and bucket boundaries.
+     *
+     * Each bucket is represented as a document in the output. The document for
+     * each bucket contains an _id field, whose value specifies the inclusive
+     * lower bound of the bucket and a count field that contains the number of
+     * documents in the bucket. The count field is included by default when the
+     * output is not specified.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bucket/
+     *
+     * @return Stage\Bucket
+     */
+    public function bucket()
+    {
+        return $this->addStage(new Stage\Bucket($this));
+    }
+
+    /**
      * @return Expr
      */
     public function expr()

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -345,6 +345,20 @@ class Builder
     }
 
     /**
+     * Groups incoming documents based on the value of a specified expression,
+     * then computes the count of documents in each distinct group.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sortByCount/
+     *
+     * @param string $expression The expression to group by
+     * @return Stage\SortByCount
+     */
+    public function sortByCount($expression)
+    {
+        return $this->addStage(new Stage\SortByCount($this, $expression));
+    }
+
+    /**
      * Deconstructs an array field from the input documents to output a document
      * for each element. Each output document is the input document with the
      * value of the array field replaced by the element.

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -115,6 +115,19 @@ class Builder
     }
 
     /**
+     * Returns a document that contains a count of the number of documents input
+     * to the stage.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/count/
+     *
+     * @return Stage\Count
+     */
+    public function count($fieldName)
+    {
+        return $this->addStage(new Stage\Count($this, $fieldName));
+    }
+
+    /**
      * @return Expr
      */
     public function expr()

--- a/lib/Doctrine/MongoDB/Aggregation/Builder.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Builder.php
@@ -300,6 +300,23 @@ class Builder
     }
 
     /**
+     * Promotes a specified document to the top level and replaces all other
+     * fields.
+     *
+     * The operation replaces all existing fields in the input document,
+     * including the _id field. You can promote an existing embedded document to
+     * the top level, or create a new document for promotion.
+     *
+     * @param string $expression
+     *
+     * @return Stage\ReplaceRoot
+     */
+    public function replaceRoot($expression = null)
+    {
+        return $this->addStage(new Stage\ReplaceRoot($this, $expression));
+    }
+
+    /**
      * Randomly selects the specified number of documents from its input.
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/

--- a/lib/Doctrine/MongoDB/Aggregation/Expr.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Expr.php
@@ -285,7 +285,7 @@ class Expr
      *
      * For expression objects, it calls getExpression on the expression object.
      * For arrays, it recursively calls itself for each array item. Other values
-     * are returned directly
+     * are returned directly.
      *
      * @param mixed|self $expression
      * @return string|array

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -81,6 +81,27 @@ abstract class Stage
     }
 
     /**
+     * Categorizes incoming documents into a specific number of groups, called
+     * buckets, based on a specified expression.
+     *
+     * Bucket boundaries are automatically determined in an attempt to evenly
+     * distribute the documents into the specified number of buckets. Each
+     * bucket is represented as a document in the output. The document for each
+     * bucket contains an _id field, whose value specifies the inclusive lower
+     * bound and the exclusive upper bound for the bucket, and a count field
+     * that contains the number of documents in the bucket. The count field is
+     * included by default when the output is not specified.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bucketAuto/
+     *
+     * @return Stage\BucketAuto
+     */
+    public function bucketAuto()
+    {
+        return $this->builder->bucketAuto();
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      * You can only use this as the first stage of a pipeline.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -234,6 +234,23 @@ abstract class Stage
     }
 
     /**
+     * Promotes a specified document to the top level and replaces all other
+     * fields.
+     *
+     * The operation replaces all existing fields in the input document,
+     * including the _id field. You can promote an existing embedded document to
+     * the top level, or create a new document for promotion.
+     *
+     * @param string $expression
+     *
+     * @return Stage\ReplaceRoot
+     */
+    public function replaceRoot($expression = null)
+    {
+        return $this->builder->replaceRoot($expression);
+    }
+
+    /**
      * Randomly selects the specified number of documents from its input.
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/sample/

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -62,6 +62,25 @@ abstract class Stage
     }
 
     /**
+     * Categorizes incoming documents into groups, called buckets, based on a
+     * specified expression and bucket boundaries.
+     *
+     * Each bucket is represented as a document in the output. The document for
+     * each bucket contains an _id field, whose value specifies the inclusive
+     * lower bound of the bucket and a count field that contains the number of
+     * documents in the bucket. The count field is included by default when the
+     * output is not specified.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/bucket/
+     *
+     * @return Stage\Bucket
+     */
+    public function bucket()
+    {
+        return $this->builder->bucket();
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      * You can only use this as the first stage of a pipeline.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -141,6 +141,20 @@ abstract class Stage
     }
 
     /**
+     * Performs a recursive search on a collection, with options for restricting
+     * the search by recursion depth and query filter.
+     *
+     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
+     *
+     * @param string $from
+     * @return Stage\GraphLookup
+     */
+    public function graphLookup($from)
+    {
+        return $this->builder->graphLookup($from);
+    }
+
+    /**
      * Groups documents by some specified expression and outputs to the next
      * stage a document for each distinct grouping.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -261,6 +261,20 @@ abstract class Stage
     }
 
     /**
+     * Groups incoming documents based on the value of a specified expression,
+     * then computes the count of documents in each distinct group.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sortByCount/
+     *
+     * @param string $expression The expression to group by
+     * @return Stage\SortByCount
+     */
+    public function sortByCount($expression)
+    {
+        return $this->builder->sortByCount($expression);
+    }
+
+    /**
      * Sorts all input documents and returns them to the pipeline in sorted order.
      *
      * If sorting by multiple fields, the first argument should be an array of

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -159,7 +159,8 @@ abstract class Stage
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/graphLookup/
      *
-     * @param string $from
+     * @param string $from Target collection for the $graphLookup operation to
+     * search, recursively matching the connectFromField to the connectToField.
      * @return Stage\GraphLookup
      */
     public function graphLookup($from)
@@ -282,7 +283,8 @@ abstract class Stage
      * including the _id field. You can promote an existing embedded document to
      * the top level, or create a new document for promotion.
      *
-     * @param string $expression
+     * @param string|null $expression Optional. A replacement expression that
+     * resolves to a document.
      *
      * @return Stage\ReplaceRoot
      */

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -102,6 +102,19 @@ abstract class Stage
     }
 
     /**
+     * Returns a document that contains a count of the number of documents input
+     * to the stage.
+     *
+     * @see https://docs.mongodb.com/manual/reference/operator/aggregation/count/
+     *
+     * @return Stage\Count
+     */
+    public function count($fieldName)
+    {
+        return $this->builder->count($fieldName);
+    }
+
+    /**
      * Processes multiple aggregation pipelines within a single stage on the
      * same set of input documents.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Stage.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage.php
@@ -102,6 +102,20 @@ abstract class Stage
     }
 
     /**
+     * Processes multiple aggregation pipelines within a single stage on the
+     * same set of input documents.
+     *
+     * Each sub-pipeline has its own field in the output document where its
+     * results are stored as an array of documents.
+     *
+     * @return Stage\Facet
+     */
+    public function facet()
+    {
+        return $this->builder->facet();
+    }
+
+    /**
      * Outputs documents in order of nearest to farthest from a specified point.
      * You can only use this as the first stage of a pipeline.
      *

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Expr;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Abstract class with common functionality for $bucket and $bucketAuto stages
+ *
+ * @internal
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+abstract class AbstractBucket extends Stage
+{
+    /**
+     * @var Bucket\BucketOutput|null
+     */
+    protected $output;
+
+    /**
+     * @var Expr
+     */
+    protected $groupBy;
+
+    /**
+     * @param array|Expr $expression
+     * @return $this
+     */
+    public function groupBy($expression)
+    {
+        $this->groupBy = $expression;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        $stage = [
+            '$bucket' => [
+                'groupBy' => Expr::convertExpression($this->groupBy),
+            ] + $this->getExtraPipelineFields(),
+        ];
+
+        if ($this->output !== null) {
+            $stage['$bucket']['output'] = $this->output->getExpression();
+        }
+
+        return $stage;
+    }
+
+    /**
+     * @return array
+     */
+    abstract protected function getExtraPipelineFields();
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -25,6 +25,9 @@ abstract class AbstractBucket extends Stage
     protected $groupBy;
 
     /**
+     * An expression to group documents by. To specify a field path, prefix the
+     * field name with a dollar sign $ and enclose it in quotes.
+     *
      * @param array|Expr $expression
      * @return $this
      */

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AddFields.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AddFields.php
@@ -27,9 +27,7 @@ namespace Doctrine\MongoDB\Aggregation\Stage;
 class AddFields extends Operator
 {
     /**
-     * Assembles the aggregation stage
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getExpression()
     {

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
@@ -1,0 +1,153 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $bucket stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class Bucket extends Stage
+{
+    /**
+     * @var Expr
+     */
+    private $groupBy;
+
+    /**
+     * @var array
+     */
+    private $boundaries;
+
+    /**
+     * @var mixed
+     */
+    private $default;
+
+    /**
+     * @var Bucket\Output|null
+     */
+    private $output;
+
+    /**
+     * @param Builder $builder
+     */
+    public function __construct(Builder $builder)
+    {
+        parent::__construct($builder);
+    }
+
+    /**
+     * @param array|Expr $expression
+     * @return $this
+     */
+    public function groupBy($expression)
+    {
+        if (is_string($expression)) {
+            $this->groupBy = $expression;
+        } elseif (is_array($expression)) {
+            $this->groupBy = $this->ensureArrayExpression($expression);
+        } elseif ($expression instanceof Expr) {
+            $this->groupBy = $expression->getExpression();
+        } else {
+            throw new \InvalidArgumentException('Invalid expression given - must be a string, array or expression object');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array ...$boundaries
+     *
+     * @return $this
+     */
+    public function boundaries(...$boundaries)
+    {
+        $this->boundaries = $boundaries;
+        return $this;
+    }
+
+    /**
+     * @param mixed $default
+     *
+     * @return $this
+     */
+    public function defaultBucket($default)
+    {
+        $this->default = $default;
+        return $this;
+    }
+
+    /**
+     * @return Bucket\Output
+     */
+    public function output()
+    {
+        if (!$this->output) {
+            $this->output = new Stage\Bucket\Output($this->builder, $this);
+        }
+
+        return $this->output;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        $stage = [
+            '$bucket' => [
+                'groupBy' => $this->groupBy instanceof Expr ? $this->groupBy->getExpression() : (string) $this->groupBy,
+                'boundaries' => $this->boundaries,
+            ],
+        ];
+
+        if ($this->default !== null) {
+            $stage['$bucket']['default'] = $this->default;
+        }
+
+        if ($this->output !== null) {
+            $stage['$bucket']['output'] = $this->output->getExpression();
+        }
+
+        return $stage;
+    }
+
+    private function ensureArrayExpression($expression)
+    {
+        if (is_array($expression)) {
+            $array = [];
+            foreach ($expression as $index => $value) {
+                $array[$index] = $this->ensureArrayExpression($value);
+            }
+
+            return $array;
+        } elseif ($expression instanceof self) {
+            return $expression->getExpression();
+        }
+
+        return $expression;
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
@@ -41,6 +41,14 @@ class Bucket extends AbstractBucket
     private $default;
 
     /**
+     * An array of values based on the groupBy expression that specify the
+     * boundaries for each bucket.
+     *
+     * Each adjacent pair of values acts as the inclusive lower boundary and the
+     * exclusive upper boundary for the bucket. You must specify at least two
+     * boundaries. The specified values must be in ascending order and all of
+     * the same type. The exception is if the values are of mixed numeric types.
+     *
      * @param array ...$boundaries
      *
      * @return $this
@@ -52,6 +60,10 @@ class Bucket extends AbstractBucket
     }
 
     /**
+     * A literal that specifies the _id of an additional bucket that contains
+     * all documents whose groupBy expression result does not fall into a bucket
+     * specified by boundaries.
+     *
      * @param mixed $default
      *
      * @return $this
@@ -63,6 +75,10 @@ class Bucket extends AbstractBucket
     }
 
     /**
+     * A document that specifies the fields to include in the output documents
+     * in addition to the _id field. To specify the field to include, you must
+     * use accumulator expressions.
+     *
      * @return Bucket\BucketOutput
      */
     public function output()

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
@@ -1,21 +1,4 @@
 <?php
-/*
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This software consists of voluntary contributions made by many individuals
- * and is licensed under the MIT license. For more information, see
- * <http://www.doctrine-project.org>.
- */
 
 namespace Doctrine\MongoDB\Aggregation\Stage\Bucket;
 
@@ -24,24 +7,29 @@ use Doctrine\MongoDB\Aggregation\Expr;
 use Doctrine\MongoDB\Aggregation\Stage;
 
 /**
- * Fluent interface for adding an output specification to a bucket stage.
+ * Abstract class with common functionality for output objects in bucket stages
  *
+ * @internal
  * @author alcaeus <alcaeus@alcaeus.org>
  * @since 1.5
  */
-class Output extends Stage
+abstract class AbstractOutput extends Stage
 {
     /**
-     * @var Stage\Bucket
+     * @var Stage\AbstractBucket
      */
-    private $bucket;
+    protected $bucket;
 
     /**
      * @var Expr
      */
     private $expr;
 
-    public function __construct(Builder $builder, Stage\Bucket $bucket)
+    /**
+     * @param Builder $builder
+     * @param Stage\AbstractBucket $bucket
+     */
+    public function __construct(Builder $builder, Stage\AbstractBucket $bucket)
     {
         parent::__construct($builder);
 
@@ -57,21 +45,6 @@ class Output extends Stage
         return $this->expr->getExpression();
     }
 
-    public function groupBy($expression)
-    {
-        return $this->bucket->groupBy($expression);
-    }
-
-    public function boundaries(...$boundaries)
-    {
-        return $this->bucket->boundaries(...$boundaries);
-    }
-
-    public function defaultBucket($default)
-    {
-        return $this->bucket->defaultBucket($default);
-    }
-
     /**
      * Returns an array of all unique values that results from applying an
      * expression to each document in a group of documents that share the same
@@ -81,7 +54,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/addToSet/
      * @see Expr::addToSet
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function addToSet($expression)
@@ -98,7 +73,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
      * @see Expr::avg
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function avg($expression)
@@ -113,7 +90,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
      * @see Expr::expression
+     *
      * @param mixed|Expr $value
+     *
      * @return $this
      */
     public function expression($value)
@@ -127,7 +106,9 @@ class Output extends Stage
      * Set the current field for building the expression.
      *
      * @see Expr::field
+     *
      * @param string $fieldName
+     *
      * @return $this
      */
     public function field($fieldName)
@@ -144,7 +125,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/first/
      * @see Expr::first
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function first($expression)
@@ -161,7 +144,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/last/
      * @see Expr::last
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function last($expression)
@@ -177,7 +162,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
      * @see Expr::max
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function max($expression)
@@ -193,7 +180,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
      * @see Expr::min
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function min($expression)
@@ -209,7 +198,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/push/
      * @see Expr::push
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function push($expression)
@@ -226,7 +217,9 @@ class Output extends Stage
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
      * @see Expr::stdDevPop
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function stdDevPop($expression)
@@ -243,7 +236,9 @@ class Output extends Stage
      *
      * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
      * @see Expr::stdDevSamp
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function stdDevSamp($expression)
@@ -260,7 +255,9 @@ class Output extends Stage
      *
      * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
      * @see Expr::sum
+     *
      * @param mixed|Expr $expression
+     *
      * @return $this
      */
     public function sum($expression)

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/AbstractOutput.php
@@ -86,7 +86,7 @@ abstract class AbstractOutput extends Stage
     }
 
     /**
-     * Used to use an expression as field value. Can be any expression
+     * Used to use an expression as field value. Can be any expression.
      *
      * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
      * @see Expr::expression

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
@@ -17,73 +17,53 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\MongoDB\Aggregation\Stage;
+namespace Doctrine\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage;
 
 /**
- * Fluent interface for adding a $bucket stage to an aggregation pipeline.
+ * Fluent interface for adding an output specification to a bucket stage.
  *
  * @author alcaeus <alcaeus@alcaeus.org>
  * @since 1.5
  */
-class Bucket extends AbstractBucket
+class BucketAutoOutput extends AbstractOutput
 {
     /**
-     * @var array
+     * @param Builder $builder
+     * @param Stage\BucketAuto $bucket
      */
-    private $boundaries;
+    public function __construct(Builder $builder, Stage\BucketAuto $bucket)
+    {
+        parent::__construct($builder, $bucket);
+    }
 
     /**
-     * @var mixed
+     * @return Stage\BucketAuto
      */
-    private $default;
+    public function groupBy($expression)
+    {
+        return $this->bucket->groupBy($expression);
+    }
 
     /**
-     * @param array ...$boundaries
+     * @param int $buckets
      *
-     * @return $this
+     * @return Stage\BucketAuto
      */
-    public function boundaries(...$boundaries)
+    public function buckets($buckets)
     {
-        $this->boundaries = $boundaries;
-        return $this;
+        return $this->bucket->buckets($buckets);
     }
 
     /**
-     * @param mixed $default
+     * @param string $granularity
      *
-     * @return $this
+     * @return Stage\BucketAuto
      */
-    public function defaultBucket($default)
+    public function granularity($granularity)
     {
-        $this->default = $default;
-        return $this;
-    }
-
-    /**
-     * @return Bucket\BucketOutput
-     */
-    public function output()
-    {
-        if (!$this->output) {
-            $this->output = new Stage\Bucket\BucketOutput($this->builder, $this);
-        }
-
-        return $this->output;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getExtraPipelineFields()
-    {
-        $fields = ['boundaries' => $this->boundaries];
-        if ($this->default !== null) {
-            $fields['default'] = $this->default;
-        }
-
-        return $fields;
+        return $this->bucket->granularity($granularity);
     }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketAutoOutput.php
@@ -40,6 +40,9 @@ class BucketAutoOutput extends AbstractOutput
     }
 
     /**
+     * An expression to group documents by. To specify a field path, prefix the
+     * field name with a dollar sign $ and enclose it in quotes.
+     *
      * @return Stage\BucketAuto
      */
     public function groupBy($expression)
@@ -48,6 +51,8 @@ class BucketAutoOutput extends AbstractOutput
     }
 
     /**
+     * A positive 32-bit integer that specifies the number of buckets into which input documents are grouped.
+     *
      * @param int $buckets
      *
      * @return Stage\BucketAuto
@@ -58,6 +63,10 @@ class BucketAutoOutput extends AbstractOutput
     }
 
     /**
+     * A string that specifies the preferred number series to use to ensure that
+     * the calculated boundary edges end on preferred round numbers or their
+     * powers of 10.
+     *
      * @param string $granularity
      *
      * @return Stage\BucketAuto

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
@@ -17,73 +17,49 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace Doctrine\MongoDB\Aggregation\Stage;
+namespace Doctrine\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage;
 
 /**
- * Fluent interface for adding a $bucket stage to an aggregation pipeline.
+ * Fluent interface for adding an output specification to a bucket stage.
  *
  * @author alcaeus <alcaeus@alcaeus.org>
  * @since 1.5
  */
-class Bucket extends AbstractBucket
+class BucketOutput extends AbstractOutput
 {
     /**
-     * @var array
+     * @param Builder $builder
+     * @param Stage\Bucket $bucket
      */
-    private $boundaries;
+    public function __construct(Builder $builder, Stage\Bucket $bucket)
+    {
+        parent::__construct($builder, $bucket);
+    }
 
     /**
-     * @var mixed
+     * @return Stage\Bucket
      */
-    private $default;
+    public function groupBy($expression)
+    {
+        return $this->bucket->groupBy($expression);
+    }
 
     /**
-     * @param array ...$boundaries
-     *
-     * @return $this
+     * @return Stage\Bucket
      */
     public function boundaries(...$boundaries)
     {
-        $this->boundaries = $boundaries;
-        return $this;
+        return $this->bucket->boundaries(...$boundaries);
     }
 
     /**
-     * @param mixed $default
-     *
-     * @return $this
+     * @return Stage\Bucket
      */
     public function defaultBucket($default)
     {
-        $this->default = $default;
-        return $this;
-    }
-
-    /**
-     * @return Bucket\BucketOutput
-     */
-    public function output()
-    {
-        if (!$this->output) {
-            $this->output = new Stage\Bucket\BucketOutput($this->builder, $this);
-        }
-
-        return $this->output;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getExtraPipelineFields()
-    {
-        $fields = ['boundaries' => $this->boundaries];
-        if ($this->default !== null) {
-            $fields['default'] = $this->default;
-        }
-
-        return $fields;
+        return $this->bucket->defaultBucket($default);
     }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/BucketOutput.php
@@ -20,6 +20,7 @@
 namespace Doctrine\MongoDB\Aggregation\Stage\Bucket;
 
 use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
 use Doctrine\MongoDB\Aggregation\Stage;
 
 /**
@@ -40,6 +41,10 @@ class BucketOutput extends AbstractOutput
     }
 
     /**
+     * An expression to group documents by. To specify a field path, prefix the
+     * field name with a dollar sign $ and enclose it in quotes.
+     *
+     * @param mixed|Expr $expression
      * @return Stage\Bucket
      */
     public function groupBy($expression)
@@ -48,6 +53,16 @@ class BucketOutput extends AbstractOutput
     }
 
     /**
+     * An array of values based on the groupBy expression that specify the
+     * boundaries for each bucket.
+     *
+     * Each adjacent pair of values acts as the inclusive lower boundary and the
+     * exclusive upper boundary for the bucket. You must specify at least two
+     * boundaries. The specified values must be in ascending order and all of
+     * the same type. The exception is if the values are of mixed numeric types.
+     *
+     * @param array ...$boundaries
+     *
      * @return Stage\Bucket
      */
     public function boundaries(...$boundaries)
@@ -56,6 +71,12 @@ class BucketOutput extends AbstractOutput
     }
 
     /**
+     * A literal that specifies the _id of an additional bucket that contains
+     * all documents whose groupBy expression result does not fall into a bucket
+     * specified by boundaries.
+     *
+     * @param mixed $default
+     *
      * @return Stage\Bucket
      */
     public function defaultBucket($default)

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/Output.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket/Output.php
@@ -1,0 +1,272 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage\Bucket;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding an output specification to a bucket stage.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class Output extends Stage
+{
+    /**
+     * @var Stage\Bucket
+     */
+    private $bucket;
+
+    /**
+     * @var Expr
+     */
+    private $expr;
+
+    public function __construct(Builder $builder, Stage\Bucket $bucket)
+    {
+        parent::__construct($builder);
+
+        $this->bucket = $bucket;
+        $this->expr = $builder->expr();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        return $this->expr->getExpression();
+    }
+
+    public function groupBy($expression)
+    {
+        return $this->bucket->groupBy($expression);
+    }
+
+    public function boundaries(...$boundaries)
+    {
+        return $this->bucket->boundaries(...$boundaries);
+    }
+
+    public function defaultBucket($default)
+    {
+        return $this->bucket->defaultBucket($default);
+    }
+
+    /**
+     * Returns an array of all unique values that results from applying an
+     * expression to each document in a group of documents that share the same
+     * group by key. Order of the elements in the output array is unspecified.
+     *
+     * AddToSet is an accumulator operation only available in the group stage.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/addToSet/
+     * @see Expr::addToSet
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function addToSet($expression)
+    {
+        $this->expr->addToSet($expression);
+
+        return $this;
+    }
+
+    /**
+     * Returns the average value of the numeric values that result from applying
+     * a specified expression to each document in a group of documents that
+     * share the same group by key. Ignores nun-numeric values.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/avg/
+     * @see Expr::avg
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function avg($expression)
+    {
+        $this->expr->avg($expression);
+
+        return $this;
+    }
+
+    /**
+     * Used to use an expression as field value. Can be any expression
+     *
+     * @see http://docs.mongodb.org/manual/meta/aggregation-quick-reference/#aggregation-expressions
+     * @see Expr::expression
+     * @param mixed|Expr $value
+     * @return $this
+     */
+    public function expression($value)
+    {
+        $this->expr->expression($value);
+
+        return $this;
+    }
+
+    /**
+     * Set the current field for building the expression.
+     *
+     * @see Expr::field
+     * @param string $fieldName
+     * @return $this
+     */
+    public function field($fieldName)
+    {
+        $this->expr->field($fieldName);
+
+        return $this;
+    }
+
+    /**
+     * Returns the value that results from applying an expression to the first
+     * document in a group of documents that share the same group by key. Only
+     * meaningful when documents are in a defined order.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/first/
+     * @see Expr::first
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function first($expression)
+    {
+        $this->expr->first($expression);
+
+        return $this;
+    }
+
+    /**
+     * Returns the value that results from applying an expression to the last
+     * document in a group of documents that share the same group by a field.
+     * Only meaningful when documents are in a defined order.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/last/
+     * @see Expr::last
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function last($expression)
+    {
+        $this->expr->last($expression);
+
+        return $this;
+    }
+
+    /**
+     * Returns the highest value that results from applying an expression to
+     * each document in a group of documents that share the same group by key.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/max/
+     * @see Expr::max
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function max($expression)
+    {
+        $this->expr->max($expression);
+
+        return $this;
+    }
+
+    /**
+     * Returns the lowest value that results from applying an expression to each
+     * document in a group of documents that share the same group by key.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/min/
+     * @see Expr::min
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function min($expression)
+    {
+        $this->expr->min($expression);
+
+        return $this;
+    }
+
+    /**
+     * Returns an array of all values that result from applying an expression to
+     * each document in a group of documents that share the same group by key.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/push/
+     * @see Expr::push
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function push($expression)
+    {
+        $this->expr->push($expression);
+
+        return $this;
+    }
+
+    /**
+     * Calculates the population standard deviation of the input values.
+     *
+     * The argument can be any expression as long as it resolves to an array.
+     *
+     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevPop/
+     * @see Expr::stdDevPop
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function stdDevPop($expression)
+    {
+        $this->expr->stdDevPop($expression);
+
+        return $this;
+    }
+
+    /**
+     * Calculates the sample standard deviation of the input values.
+     *
+     * The argument can be any expression as long as it resolves to an array.
+     *
+     * @see https://docs.mongodb.org/manual/reference/operator/aggregation/stdDevSamp/
+     * @see Expr::stdDevSamp
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function stdDevSamp($expression)
+    {
+        $this->expr->stdDevSamp($expression);
+
+        return $this;
+    }
+
+    /**
+     * Calculates and returns the sum of all the numeric values that result from
+     * applying a specified expression to each document in a group of documents
+     * that share the same group by key. Ignores nun-numeric values.
+     *
+     * @see http://docs.mongodb.org/manual/reference/operator/aggregation/sum/
+     * @see Expr::sum
+     * @param mixed|Expr $expression
+     * @return $this
+     */
+    public function sum($expression)
+    {
+        $this->expr->sum($expression);
+
+        return $this;
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
@@ -23,42 +23,37 @@ use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Stage;
 
 /**
- * Fluent interface for adding a $bucket stage to an aggregation pipeline.
+ * Fluent interface for adding a $bucketAuto stage to an aggregation pipeline.
  *
  * @author alcaeus <alcaeus@alcaeus.org>
  * @since 1.5
  */
-class Bucket extends AbstractBucket
+class BucketAuto extends AbstractBucket
 {
     /**
-     * @var array
+     * @var int
      */
-    private $boundaries;
+    private $buckets;
 
     /**
-     * @var mixed
+     * @var string
      */
-    private $default;
+    private $granularity;
 
     /**
-     * @param array ...$boundaries
+     * @param int $buckets
      *
      * @return $this
      */
-    public function boundaries(...$boundaries)
+    public function buckets($buckets)
     {
-        $this->boundaries = $boundaries;
+        $this->buckets = $buckets;
         return $this;
     }
 
-    /**
-     * @param mixed $default
-     *
-     * @return $this
-     */
-    public function defaultBucket($default)
+    public function granularity($granularity)
     {
-        $this->default = $default;
+        $this->granularity = $granularity;
         return $this;
     }
 
@@ -68,7 +63,7 @@ class Bucket extends AbstractBucket
     public function output()
     {
         if (!$this->output) {
-            $this->output = new Stage\Bucket\BucketOutput($this->builder, $this);
+            $this->output = new Stage\Bucket\BucketAutoOutput($this->builder, $this);
         }
 
         return $this->output;
@@ -79,9 +74,9 @@ class Bucket extends AbstractBucket
      */
     protected function getExtraPipelineFields()
     {
-        $fields = ['boundaries' => $this->boundaries];
-        if ($this->default !== null) {
-            $fields['default'] = $this->default;
+        $fields = ['buckets' => $this->buckets];
+        if ($this->granularity !== null) {
+            $fields['granularity'] = $this->granularity;
         }
 
         return $fields;

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
@@ -41,6 +41,9 @@ class BucketAuto extends AbstractBucket
     private $granularity;
 
     /**
+     * A positive 32-bit integer that specifies the number of buckets into which
+     * input documents are grouped.
+     *
      * @param int $buckets
      *
      * @return $this
@@ -51,6 +54,15 @@ class BucketAuto extends AbstractBucket
         return $this;
     }
 
+    /**
+     * A string that specifies the preferred number series to use to ensure that
+     * the calculated boundary edges end on preferred round numbers or their
+     * powers of 10.
+     *
+     * @param string $granularity
+     *
+     * @return $this
+     */
     public function granularity($granularity)
     {
         $this->granularity = $granularity;
@@ -58,6 +70,10 @@ class BucketAuto extends AbstractBucket
     }
 
     /**
+     * A document that specifies the fields to include in the output documents
+     * in addition to the _id field. To specify the field to include, you must
+     * use accumulator expressions.
+     *
      * @return Bucket\BucketOutput
      */
     public function output()

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Count.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Count.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $count stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class Count extends Stage
+{
+    /**
+     * @var string
+     */
+    private $fieldName;
+
+    /**
+     * @param Builder $builder
+     * @param string $fieldName
+     */
+    public function __construct(Builder $builder, $fieldName)
+    {
+        parent::__construct($builder);
+
+        $this->fieldName = $fieldName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        return [
+            '$count' => $this->fieldName
+        ];
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $facet stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class Facet extends Stage
+{
+    /**
+     * @var Builder[]
+     */
+    private $pipelines = [];
+
+    /**
+     * @var string
+     */
+    private $fieldName;
+
+    /**
+     * Assembles the aggregation stage
+     *
+     * @return array
+     */
+    public function getExpression()
+    {
+        return [
+            '$facet' => array_map(function (Builder $builder) { return $builder->getPipeline(); }, $this->pipelines),
+        ];
+    }
+
+    /**
+     * @param string $fieldName
+     * @return $this
+     */
+    public function field($fieldName)
+    {
+        $this->fieldName = $fieldName;
+        return $this;
+    }
+
+    /**
+     * @param Builder|Stage $builder
+     * @return $this
+     */
+    public function pipeline($builder)
+    {
+        if (!$this->fieldName) {
+            throw new \LogicException(__METHOD__ . ' requires you set a current field using field().');
+        }
+
+        if ($builder instanceof Stage) {
+            $builder = $builder->builder;
+        }
+
+        if (!$builder instanceof Builder) {
+            throw new \InvalidArgumentException(__METHOD__ . ' expects either an aggregation builder or an aggregation stage.');
+        }
+
+        $this->pipelines[$this->fieldName] = $builder;
+        return $this;
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
@@ -41,9 +41,7 @@ class Facet extends Stage
     private $fieldName;
 
     /**
-     * Assembles the aggregation stage
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getExpression()
     {
@@ -53,7 +51,10 @@ class Facet extends Stage
     }
 
     /**
+     * Set the current field for building the pipeline stage.
+     *
      * @param string $fieldName
+     *
      * @return $this
      */
     public function field($fieldName)
@@ -63,6 +64,8 @@ class Facet extends Stage
     }
 
     /**
+     * Use the given pipeline for the current field.
+     *
      * @param Builder|Stage $builder
      * @return $this
      */

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Facet.php
@@ -38,7 +38,7 @@ class Facet extends Stage
     /**
      * @var string
      */
-    private $fieldName;
+    private $field;
 
     /**
      * {@inheritdoc}
@@ -53,13 +53,13 @@ class Facet extends Stage
     /**
      * Set the current field for building the pipeline stage.
      *
-     * @param string $fieldName
+     * @param string $field
      *
      * @return $this
      */
-    public function field($fieldName)
+    public function field($field)
     {
-        $this->fieldName = $fieldName;
+        $this->field = $field;
         return $this;
     }
 
@@ -71,7 +71,7 @@ class Facet extends Stage
      */
     public function pipeline($builder)
     {
-        if (!$this->fieldName) {
+        if (!$this->field) {
             throw new \LogicException(__METHOD__ . ' requires you set a current field using field().');
         }
 
@@ -83,7 +83,7 @@ class Facet extends Stage
             throw new \InvalidArgumentException(__METHOD__ . ' expects either an aggregation builder or an aggregation stage.');
         }
 
-        $this->pipelines[$this->fieldName] = $builder;
+        $this->pipelines[$this->field] = $builder;
         return $this;
     }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -75,7 +75,8 @@ class GraphLookup extends Stage
      * Lookup constructor.
      *
      * @param Builder $builder
-     * @param string $from
+     * @param string $from Target collection for the $graphLookup operation to
+     * search, recursively matching the connectFromField to the connectToField.
      */
     public function __construct(Builder $builder, $from)
     {
@@ -85,12 +86,21 @@ class GraphLookup extends Stage
         $this->restrictSearchWithMatch = $this->createMatchObject();
     }
 
+    /**
+     * @return GraphLookup\Match
+     */
     protected function createMatchObject()
     {
         return new Stage\GraphLookup\Match($this->builder, $this);
     }
 
     /**
+     * Target collection for the $graphLookup operation to search, recursively
+     * matching the connectFromField to the connectToField.
+     *
+     * The from collection cannot be sharded and must be in the same database as
+     * any other collections used in the operation.
+     *
      * @param string $from
      *
      * @return $this
@@ -103,6 +113,12 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Expression that specifies the value of the connectFromField with which to
+     * start the recursive search.
+     *
+     * Optionally, startWith may be array of values, each of which is
+     * individually followed through the traversal process.
+     *
      * @param string|array|Expr $expression
      *
      * @return $this
@@ -115,6 +131,12 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Field name whose value $graphLookup uses to recursively match against the
+     * connectToField of other documents in the collection.
+     *
+     * Optionally, connectFromField may be an array of field names, each of
+     * which is individually followed through the traversal process.
+     *
      * @param string $connectFromField
      *
      * @return $this
@@ -127,6 +149,9 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Field name in other documents against which to match the value of the
+     * field specified by the connectFromField parameter.
+     *
      * @param string $connectToField
      *
      * @return $this
@@ -139,6 +164,11 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Name of the array field added to each output document.
+     *
+     * Contains the documents traversed in the $graphLookup stage to reach the
+     * document.
+     *
      * @param string $alias
      *
      * @return $this
@@ -151,6 +181,8 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Non-negative integral number specifying the maximum recursion depth.
+     *
      * @param int $maxDepth
      *
      * @return $this
@@ -163,6 +195,12 @@ class GraphLookup extends Stage
     }
 
     /**
+     * Name of the field to add to each traversed document in the search path.
+     *
+     * The value of this field is the recursion depth for the document,
+     * represented as a NumberLong. Recursion depth value starts at zero, so the
+     * first lookup corresponds to zero depth.
+     *
      * @param string $depthField
      *
      * @return $this
@@ -175,6 +213,8 @@ class GraphLookup extends Stage
     }
 
     /**
+     * A document specifying additional conditions for the recursive search.
+     *
      * @return GraphLookup\Match
      */
     public function restrictSearchWithMatch()

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $graphLookup stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class GraphLookup extends Stage
+{
+    /**
+     * @var string
+     */
+    private $from;
+
+    /**
+     * @var string|Expr|array
+     */
+    private $startWith;
+
+    /**
+     * @var string
+     */
+    private $connectFromField;
+
+    /**
+     * @var string
+     */
+    private $connectToField;
+
+    /**
+     * @var string
+     */
+    private $as;
+
+    /**
+     * @var int
+     */
+    private $maxDepth;
+
+    /**
+     * @var string
+     */
+    private $depthField;
+
+    /**
+     * @var Stage\GraphLookup\Match
+     */
+    private $restrictSearchWithMatch;
+
+    /**
+     * Lookup constructor.
+     *
+     * @param Builder $builder
+     * @param string $from
+     */
+    public function __construct(Builder $builder, $from)
+    {
+        parent::__construct($builder);
+
+        $this->from($from);
+        $this->restrictSearchWithMatch = $this->createMatchObject();
+    }
+
+    protected function createMatchObject()
+    {
+        return new Stage\GraphLookup\Match($this->builder, $this);
+    }
+
+    /**
+     * @param string $from
+     *
+     * @return $this
+     */
+    public function from($from)
+    {
+        $this->from = $from;
+
+        return $this;
+    }
+
+    /**
+     * @param string|array|Expr $expression
+     *
+     * @return $this
+     */
+    public function startWith($expression)
+    {
+        $this->startWith = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @param string $connectFromField
+     *
+     * @return $this
+     */
+    public function connectFromField($connectFromField)
+    {
+        $this->connectFromField = $connectFromField;
+
+        return $this;
+    }
+
+    /**
+     * @param string $connectToField
+     *
+     * @return $this
+     */
+    public function connectToField($connectToField)
+    {
+        $this->connectToField = $connectToField;
+
+        return $this;
+    }
+
+    /**
+     * @param string $alias
+     *
+     * @return $this
+     */
+    public function alias($alias)
+    {
+        $this->as = $alias;
+
+        return $this;
+    }
+
+    /**
+     * @param int $maxDepth
+     *
+     * @return $this
+     */
+    public function maxDepth($maxDepth)
+    {
+        $this->maxDepth = $maxDepth;
+
+        return $this;
+    }
+
+    /**
+     * @param string $depthField
+     *
+     * @return $this
+     */
+    public function depthField($depthField)
+    {
+        $this->depthField = $depthField;
+
+        return $this;
+    }
+
+    /**
+     * @return GraphLookup\Match
+     */
+    public function restrictSearchWithMatch()
+    {
+        return $this->restrictSearchWithMatch;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        $graphLookup = [
+            'from' => $this->from,
+            'startWith' => Expr::convertExpression($this->startWith),
+            'connectFromField' => $this->connectFromField,
+            'connectToField' => $this->connectToField,
+            'as' => $this->as,
+            'restrictSearchWithMatch' => $this->restrictSearchWithMatch->getExpression(),
+        ];
+
+        foreach (['maxDepth', 'depthField'] as $field) {
+            if ($this->$field === null) {
+                continue;
+            }
+
+            $graphLookup[$field] = $this->$field;
+        }
+
+        return ['$graphLookup' => $graphLookup];
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup/Match.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup/Match.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Doctrine\MongoDB\Aggregation\Stage\GraphLookup;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
+use Doctrine\MongoDB\Aggregation\Stage\GraphLookup;
+use Doctrine\MongoDB\Aggregation\Stage\Match as BaseMatch;
+
+class Match extends BaseMatch
+{
+    /**
+     * @var GraphLookup
+     */
+    private $graphLookup;
+
+    /**
+     * @param Builder $builder
+     * @param GraphLookup $graphLookup
+     */
+    public function __construct(Builder $builder, GraphLookup $graphLookup)
+    {
+        parent::__construct($builder);
+
+        $this->graphLookup = $graphLookup;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        return $this->query->getQuery();
+    }
+
+    /**
+     * @param string $from
+     *
+     * @return GraphLookup
+     */
+    public function from($from)
+    {
+        return $this->graphLookup->from($from);
+    }
+
+    /**
+     * @param string|array|Expr $expression
+     *
+     * @return GraphLookup
+     */
+    public function startWith($expression)
+    {
+        return $this->graphLookup->startWith($expression);
+    }
+
+    /**
+     * @param string $connectFromField
+     *
+     * @return GraphLookup
+     */
+    public function connectFromField($connectFromField)
+    {
+        return $this->graphLookup->connectFromField($connectFromField);
+    }
+
+    /**
+     * @param string $connectToField
+     *
+     * @return GraphLookup
+     */
+    public function connectToField($connectToField)
+    {
+        return $this->graphLookup->connectToField($connectToField);
+    }
+
+    /**
+     * @param string $alias
+     *
+     * @return GraphLookup
+     */
+    public function alias($alias)
+    {
+        return $this->graphLookup->alias($alias);
+    }
+
+    /**
+     * @param int $maxDepth
+     *
+     * @return GraphLookup
+     */
+    public function maxDepth($maxDepth)
+    {
+        return $this->graphLookup->maxDepth($maxDepth);
+    }
+
+    /**
+     * @param string $depthField
+     *
+     * @return GraphLookup
+     */
+    public function depthField($depthField)
+    {
+        return $this->graphLookup->depthField($depthField);
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup/Match.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup/Match.php
@@ -34,6 +34,12 @@ class Match extends BaseMatch
     }
 
     /**
+     * Target collection for the $graphLookup operation to search, recursively
+     * matching the connectFromField to the connectToField.
+     *
+     * The from collection cannot be sharded and must be in the same database as
+     * any other collections used in the operation.
+     *
      * @param string $from
      *
      * @return GraphLookup
@@ -44,6 +50,12 @@ class Match extends BaseMatch
     }
 
     /**
+     * Expression that specifies the value of the connectFromField with which to
+     * start the recursive search.
+     *
+     * Optionally, startWith may be array of values, each of which is
+     * individually followed through the traversal process.
+     *
      * @param string|array|Expr $expression
      *
      * @return GraphLookup
@@ -54,6 +66,12 @@ class Match extends BaseMatch
     }
 
     /**
+     * Field name whose value $graphLookup uses to recursively match against the
+     * connectToField of other documents in the collection.
+     *
+     * Optionally, connectFromField may be an array of field names, each of
+     * which is individually followed through the traversal process.
+     *
      * @param string $connectFromField
      *
      * @return GraphLookup
@@ -64,6 +82,9 @@ class Match extends BaseMatch
     }
 
     /**
+     * Field name in other documents against which to match the value of the
+     * field specified by the connectFromField parameter.
+     *
      * @param string $connectToField
      *
      * @return GraphLookup
@@ -74,6 +95,11 @@ class Match extends BaseMatch
     }
 
     /**
+     * Name of the array field added to each output document.
+     *
+     * Contains the documents traversed in the $graphLookup stage to reach the
+     * document.
+     *
      * @param string $alias
      *
      * @return GraphLookup
@@ -84,6 +110,8 @@ class Match extends BaseMatch
     }
 
     /**
+     * Non-negative integral number specifying the maximum recursion depth.
+     *
      * @param int $maxDepth
      *
      * @return GraphLookup
@@ -94,6 +122,12 @@ class Match extends BaseMatch
     }
 
     /**
+     * Name of the field to add to each traversed document in the search path.
+     *
+     * The value of this field is the recursion depth for the document,
+     * represented as a NumberLong. Recursion depth value starts at zero, so the
+     * first lookup corresponds to zero depth.
+     *
      * @param string $depthField
      *
      * @return GraphLookup

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Lookup.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Lookup.php
@@ -54,7 +54,8 @@ class Lookup extends Stage
      * Lookup constructor.
      *
      * @param Builder $builder
-     * @param string $from
+     * @param string $from Specifies the collection in the same database to
+     * perform the join with.
      */
     public function __construct(Builder $builder, $from)
     {
@@ -64,6 +65,10 @@ class Lookup extends Stage
     }
 
     /**
+     * Specifies the collection in the same database to perform the join with.
+     *
+     * The from collection cannot be sharded.
+     *
      * @param string $from
      *
      * @return $this
@@ -76,6 +81,13 @@ class Lookup extends Stage
     }
 
     /**
+     * Specifies the field from the documents input to the $lookup stage.
+     *
+     * $lookup performs an equality match on the localField to the foreignField
+     * from the documents of the from collection. If an input document does not
+     * contain the localField, the $lookup treats the field as having a value of
+     * null for matching purposes.
+     *
      * @param string $localField
      *
      * @return $this
@@ -88,6 +100,13 @@ class Lookup extends Stage
     }
 
     /**
+     * Specifies the field from the documents in the from collection.
+     *
+     * $lookup performs an equality match on the foreignField to the localField
+     * from the input documents. If a document in the from collection does not
+     * contain the foreignField, the $lookup treats the value as null for
+     * matching purposes.
+     *
      * @param string $foreignField
      *
      * @return $this
@@ -100,6 +119,12 @@ class Lookup extends Stage
     }
 
     /**
+     * Specifies the name of the new array field to add to the input documents.
+     *
+     * The new array field contains the matching documents from the from
+     * collection. If the specified name already exists in the input document,
+     * the existing field is overwritten.
+     *
      * @param string $alias
      *
      * @return $this

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Project.php
@@ -62,7 +62,7 @@ class Project extends Operator
     /**
      * Shorthand method to exclude the _id field.
      *
-     * @deprecated Deprecated in 1.5, please use @see excludeFields.
+     * @deprecated Deprecated in 1.5, please use {@link excludeFields()}.
      * @param bool $exclude
      * @return $this
      */

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Project.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Project.php
@@ -61,11 +61,15 @@ class Project extends Operator
 
     /**
      * Shorthand method to exclude the _id field.
+     *
+     * @deprecated Deprecated in 1.5, please use @see excludeFields.
      * @param bool $exclude
      * @return $this
      */
     public function excludeIdField($exclude = true)
     {
+        @trigger_error(__METHOD__ . ' has been deprecated in favor of excludeFields.', E_USER_DEPRECATED);
+
         return $this->field('_id')->expression( ! $exclude);
     }
 
@@ -79,6 +83,25 @@ class Project extends Operator
     {
         foreach ($fields as $fieldName) {
             $this->field($fieldName)->expression(true);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Shorthand method to define which fields to be excluded.
+     *
+     * If you specify the exclusion of a field other than _id, you cannot employ
+     * any other $project specification forms.
+     *
+     * @since 1.5
+     * @param array $fields
+     * @return $this
+     */
+    public function excludeFields(array $fields)
+    {
+        foreach ($fields as $fieldName) {
+            $this->field($fieldName)->expression(false);
         }
 
         return $this;

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -37,7 +37,8 @@ class ReplaceRoot extends Operator
 
     /**
      * @param Builder $builder
-     * @param string|null $expression
+     * @param string|null $expression Optional. A replacement expression that
+     * resolves to a document.
      */
     public function __construct(Builder $builder, $expression = null)
     {

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Expr;
+
+/**
+ * Fluent interface for adding a $replaceRoot stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class ReplaceRoot extends Operator
+{
+    /**
+     * @var string|null
+     */
+    private $expression;
+
+    /**
+     * @param Builder $builder
+     * @param string|null $expression
+     */
+    public function __construct(Builder $builder, $expression = null)
+    {
+        parent::__construct($builder);
+
+        $this->expression = $expression;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpression()
+    {
+        return [
+            '$replaceRoot' => $this->expression !== null ? Expr::convertExpression($this->expression) : $this->expr->getExpression()
+        ];
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/SortByCount.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/SortByCount.php
@@ -37,7 +37,9 @@ class SortByCount extends Stage
 
     /**
      * @param Builder $builder
-     * @param string $fieldName
+     * @param string $fieldName Expression to group by. To specify a field path,
+     * prefix the field name with a dollar sign $ and enclose it in quotes.
+     * The expression can not evaluate to an object.
      */
     public function __construct(Builder $builder, $fieldName)
     {
@@ -47,9 +49,7 @@ class SortByCount extends Stage
     }
 
     /**
-     * Assembles the aggregation stage
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getExpression()
     {

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/SortByCount.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/SortByCount.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\MongoDB\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Builder;
+use Doctrine\MongoDB\Aggregation\Stage;
+
+/**
+ * Fluent interface for adding a $sortByCount stage to an aggregation pipeline.
+ *
+ * @author alcaeus <alcaeus@alcaeus.org>
+ * @since 1.5
+ */
+class SortByCount extends Stage
+{
+    /**
+     * @var string
+     */
+    private $fieldName;
+
+    /**
+     * @param Builder $builder
+     * @param string $fieldName
+     */
+    public function __construct(Builder $builder, $fieldName)
+    {
+        parent::__construct($builder);
+
+        $this->fieldName = (string) $fieldName;
+    }
+
+    /**
+     * Assembles the aggregation stage
+     *
+     * @return array
+     */
+    public function getExpression()
+    {
+        return [
+            '$sortByCount' => $this->fieldName
+        ];
+    }
+}

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Unwind.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Unwind.php
@@ -57,9 +57,7 @@ class Unwind extends Stage
     }
 
     /**
-     * Assembles the aggregation stage
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getExpression()
     {

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\BucketAuto;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class BucketAutoTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testBucketAutoStage()
+    {
+        $bucketStage = new BucketAuto($this->getTestAggregationBuilder());
+        $bucketStage
+            ->groupBy('$someField')
+            ->buckets(3)
+            ->granularity('R10')
+            ->output()
+                ->field('averageValue')
+                ->avg('$value');
+
+        $this->assertSame(['$bucket' => [
+            'groupBy' => '$someField',
+            'buckets' => 3,
+            'granularity' => 'R10',
+            'output' => ['averageValue' => ['$avg' => '$value']]
+        ]], $bucketStage->getExpression());
+    }
+
+    public function testBucketAutoFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->bucketAuto()
+            ->groupBy('$someField')
+            ->buckets(3)
+            ->granularity('R10')
+            ->output()
+                ->field('averageValue')
+                ->avg('$value');
+
+        $this->assertSame([['$bucket' => [
+            'groupBy' => '$someField',
+            'buckets' => 3,
+            'granularity' => 'R10',
+            'output' => ['averageValue' => ['$avg' => '$value']]
+        ]]], $builder->getPipeline());
+    }
+
+    public function testBucketAutoSkipsUndefinedProperties()
+    {
+        $bucketStage = new BucketAuto($this->getTestAggregationBuilder());
+        $bucketStage
+            ->groupBy('$someField')
+            ->buckets(3);
+
+        $this->assertSame(['$bucket' => [
+            'groupBy' => '$someField',
+            'buckets' => 3,
+        ]], $bucketStage->getExpression());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\Bucket;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class BucketTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testBucketStage()
+    {
+        $bucketStage = new Bucket($this->getTestAggregationBuilder());
+        $bucketStage
+            ->groupBy('$someField')
+            ->boundaries(1, 2, 3)
+            ->defaultBucket(0)
+            ->output()
+                ->field('averageValue')
+                ->avg('$value');
+
+        $this->assertSame(['$bucket' => [
+            'groupBy' => '$someField',
+            'boundaries' => [1, 2, 3],
+            'default' => 0,
+            'output' => ['averageValue' => ['$avg' => '$value']]
+        ]], $bucketStage->getExpression());
+    }
+
+    public function testBucketFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->bucket()
+            ->groupBy('$someField')
+            ->boundaries(1, 2, 3)
+            ->defaultBucket(0)
+            ->output()
+            ->field('averageValue')
+            ->avg('$value');
+
+        $this->assertSame([['$bucket' => [
+            'groupBy' => '$someField',
+            'boundaries' => [1, 2, 3],
+            'default' => 0,
+            'output' => ['averageValue' => ['$avg' => '$value']]
+        ]]], $builder->getPipeline());
+    }
+
+    public function testBucketSkipsUndefinedProperties()
+    {
+        $bucketStage = new Bucket($this->getTestAggregationBuilder());
+        $bucketStage
+            ->groupBy('$someField')
+            ->boundaries(1, 2, 3);
+
+        $this->assertSame(['$bucket' => [
+            'groupBy' => '$someField',
+            'boundaries' => [1, 2, 3],
+        ]], $bucketStage->getExpression());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/CountTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/CountTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\Count;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class CountTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testCountStage()
+    {
+        $countStage = new Count($this->getTestAggregationBuilder(), 'document_count');
+
+        $this->assertSame(['$count' => 'document_count'], $countStage->getExpression());
+    }
+
+    public function testCountFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->count('document_count');
+
+        $this->assertSame([['$count' => 'document_count']], $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/FacetTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/FacetTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\Facet;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class FacetTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testFacetStage()
+    {
+        $nestedBuilder = $this->getTestAggregationBuilder();
+        $nestedBuilder->sortByCount('$tags');
+
+        $facetStage = new Facet($this->getTestAggregationBuilder());
+        $facetStage
+            ->field('someField')
+            ->pipeline($nestedBuilder)
+            ->field('otherField')
+            ->pipeline($this->getTestAggregationBuilder()->sortByCount('$comments'));
+
+        $this->assertSame([
+            '$facet' => [
+                'someField' => [['$sortByCount' => '$tags']],
+                'otherField' => [['$sortByCount' => '$comments']],
+            ]
+        ], $facetStage->getExpression());
+    }
+
+    public function testFacetFromBuilder()
+    {
+        $nestedBuilder = $this->getTestAggregationBuilder();
+        $nestedBuilder->sortByCount('$tags');
+
+        $builder = $this->getTestAggregationBuilder();
+        $builder->facet()
+            ->field('someField')
+            ->pipeline($nestedBuilder)
+            ->field('otherField')
+            ->pipeline($this->getTestAggregationBuilder()->sortByCount('$comments'));
+
+        $this->assertSame([[
+            '$facet' => [
+                'someField' => [['$sortByCount' => '$tags']],
+                'otherField' => [['$sortByCount' => '$comments']],
+            ]
+        ]], $builder->getPipeline());
+    }
+
+    public function testFacetThrowsExceptionWithoutFieldName()
+    {
+        $facetStage = new Facet($this->getTestAggregationBuilder());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('requires you set a current field using field().');
+        $facetStage->pipeline($this->getTestAggregationBuilder());
+    }
+
+    public function testFacetThrowsExceptionOnInvalidPipeline()
+    {
+        $facetStage = new Facet($this->getTestAggregationBuilder());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects either an aggregation builder or an aggregation stage.');
+        $facetStage
+            ->field('someField')
+            ->pipeline(new \stdClass());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/GraphLookupTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\GraphLookup;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class GraphLookupTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testGraphLookupStage()
+    {
+        $graphLookupStage = new GraphLookup($this->getTestAggregationBuilder(), 'employees');
+        $graphLookupStage
+            ->startWith('$reportsTo')
+            ->connectFromField('reportsTo')
+            ->connectToField('name')
+            ->alias('reportingHierarchy');
+
+        $this->assertSame(
+            ['$graphLookup' => [
+                'from' => 'employees',
+                'startWith' => '$reportsTo',
+                'connectFromField' => 'reportsTo',
+                'connectToField' => 'name',
+                'as' => 'reportingHierarchy',
+                'restrictSearchWithMatch' => [],
+            ]],
+            $graphLookupStage->getExpression()
+        );
+    }
+
+    public function testGraphLookupFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->graphLookup('employees')
+            ->startWith('$reportsTo')
+            ->connectFromField('reportsTo')
+            ->connectToField('name')
+            ->alias('reportingHierarchy');
+
+        $this->assertSame(
+            [['$graphLookup' => [
+                'from' => 'employees',
+                'startWith' => '$reportsTo',
+                'connectFromField' => 'reportsTo',
+                'connectToField' => 'name',
+                'as' => 'reportingHierarchy',
+                'restrictSearchWithMatch' => [],
+            ]]],
+            $builder->getPipeline()
+        );
+    }
+
+    public function testGraphLookupWithMatch()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->graphLookup('employees')
+            ->startWith('$reportsTo')
+            ->restrictSearchWithMatch()
+                ->field('hobbies')
+                ->equals('golf')
+            ->connectFromField('reportsTo')
+            ->connectToField('name')
+            ->alias('reportingHierarchy')
+            ->maxDepth(1)
+            ->depthField('depth');
+
+        $this->assertSame(
+            [['$graphLookup' => [
+                'from' => 'employees',
+                'startWith' => '$reportsTo',
+                'connectFromField' => 'reportsTo',
+                'connectToField' => 'name',
+                'as' => 'reportingHierarchy',
+                'restrictSearchWithMatch' => ['hobbies' => 'golf'],
+                'maxDepth' => 1,
+                'depthField' => 'depth',
+            ]]],
+            $builder->getPipeline()
+        );
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ProjectTest.php
@@ -15,7 +15,7 @@ class ProjectTest extends TestCase
     {
         $projectStage = new Project($this->getTestAggregationBuilder());
         $projectStage
-            ->excludeIdField()
+            ->excludeFields(['_id'])
             ->includeFields(['$field', '$otherField'])
             ->field('product')
             ->multiply('$field', 5);
@@ -28,7 +28,7 @@ class ProjectTest extends TestCase
         $builder = $this->getTestAggregationBuilder();
         $builder
             ->project()
-            ->excludeIdField()
+            ->excludeFields(['_id'])
             ->includeFields(['$field', '$otherField'])
             ->field('product')
             ->multiply('$field', 5);

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\ReplaceRoot;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class ReplaceRootTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testReplaceRootStage()
+    {
+        $replaceRootStage = new ReplaceRoot($this->getTestAggregationBuilder());
+        $replaceRootStage
+            ->field('product')
+            ->multiply('$field', 5);
+
+        $this->assertSame(['$replaceRoot' => ['product' => ['$multiply' => ['$field', 5]]]], $replaceRootStage->getExpression());
+    }
+
+    public function testReplaceRootFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder
+            ->replaceRoot()
+                ->field('product')
+                ->multiply('$field', 5);
+
+        $this->assertSame([['$replaceRoot' => ['product' => ['$multiply' => ['$field', 5]]]]], $builder->getPipeline());
+    }
+
+    public function testReplaceWithEmbeddedDocument()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->replaceRoot('$some.embedded.document');
+
+        $this->assertSame([['$replaceRoot' => '$some.embedded.document']], $builder->getPipeline());
+    }
+}

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/SortByCountTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Doctrine\MongoDB\Tests\Aggregation\Stage;
+
+use Doctrine\MongoDB\Aggregation\Stage\SortByCount;
+use Doctrine\MongoDB\Tests\Aggregation\AggregationTestCase;
+use Doctrine\MongoDB\Tests\TestCase;
+
+class SortByCountTest extends TestCase
+{
+    use AggregationTestCase;
+
+    public function testSortByCountStage()
+    {
+        $sortByCountStage = new SortByCount($this->getTestAggregationBuilder(), '$expression');
+
+        $this->assertSame(['$sortByCount' => '$expression'], $sortByCountStage->getExpression());
+    }
+
+    public function testSortByCountFromBuilder()
+    {
+        $builder = $this->getTestAggregationBuilder();
+        $builder->sortByCount('$fieldName');
+
+        $this->assertSame([['$sortByCount' => '$fieldName']], $builder->getPipeline());
+    }
+}


### PR DESCRIPTION
This pull requests adds support for the new aggregation pipeline stages added in MongoDB 3.4:
- `$bucket`
- `$bucketAuto`
- `$sortByCount`
- `$replaceRoot`
- `$facet`
- `$graphLookup`
- `$count`

Note: build will fail on PHP 5.6 until I've rebased this on top of #291, but I figured it's worth getting feedback in first.