### PR TITLE
Fix BC break when converting expression objects

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1,0 +1,11 @@
+CHANGELOG for 1.6.x
+===================
+
+This changelog references the relevant changes (bug and security fixes) done
+in 1.6.x patch versions.
+
+1.6.0 (2017-08-09)
+------------------
+
+ * [#298](https://github.com/doctrine/mongodb/pull/298): Fix BC break when converting expression objects
+ * [#301](https://github.com/doctrine/mongodb/pull/301): Test against PHP 7.2

--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -1,0 +1,21 @@
+Upgrade from 1.5 to 1.6
+=======================
+
+Aggregation builder
+-------------------
+
+ * Fixes a BC break when converting expression objects in the
+ `Doctrine\MongoDB\Aggregation\Expr` class.
+ * Adds extension points to customize expression conversion in the following stages:
+    * `$bucket`
+    * `$bucketAuto`
+    * `$graphLookup`
+    * `$replaceRoot`
+
+Version support
+---------------
+ * Support for MongoDB server versions below 3.0 has been dropped. These are no
+ longer supported by MongoDB. We recommend you upgrade to a recent version
+ * The 1.5 version of the legacy driver is no longer supported. This library now
+ requires at least version 1.6.7 of the legacy driver.
+ * PHP 7.2 is also supported using [mongo-php-adapter](https://github.com/alcaeus/mongo-php-adapter)

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "1.6.x-dev"
         }
     }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -45,7 +45,7 @@ abstract class AbstractBucket extends Stage
     {
         $stage = [
             '$bucket' => [
-                'groupBy' => Expr::convertExpression($this->groupBy),
+                'groupBy' => $this->convertExpression($this->groupBy),
             ] + $this->getExtraPipelineFields(),
         ];
 
@@ -54,6 +54,21 @@ abstract class AbstractBucket extends Stage
         }
 
         return $stage;
+    }
+
+    /**
+     * Converts an expression object into an array, recursing into nested items
+     *
+     * This method is meant to be overwritten by extending classes to apply
+     * custom conversions (e.g. field name translation in MongoDB ODM) to the
+     * expression object.
+     *
+     * @param mixed|self $expression
+     * @return string|array
+     */
+    protected function convertExpression($expression)
+    {
+        return Expr::convertExpression($expression);
     }
 
     /**

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/GraphLookup.php
@@ -229,7 +229,7 @@ class GraphLookup extends Stage
     {
         $graphLookup = [
             'from' => $this->from,
-            'startWith' => Expr::convertExpression($this->startWith),
+            'startWith' => $this->convertExpression($this->startWith),
             'connectFromField' => $this->connectFromField,
             'connectToField' => $this->connectToField,
             'as' => $this->as,
@@ -245,5 +245,20 @@ class GraphLookup extends Stage
         }
 
         return ['$graphLookup' => $graphLookup];
+    }
+
+    /**
+     * Converts an expression object into an array, recursing into nested items
+     *
+     * This method is meant to be overwritten by extending classes to apply
+     * custom conversions (e.g. field name translation in MongoDB ODM) to the
+     * expression object.
+     *
+     * @param mixed|self $expression
+     * @return string|array
+     */
+    protected function convertExpression($expression)
+    {
+        return Expr::convertExpression($expression);
     }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -53,7 +53,22 @@ class ReplaceRoot extends Operator
     public function getExpression()
     {
         return [
-            '$replaceRoot' => $this->expression !== null ? Expr::convertExpression($this->expression) : $this->expr->getExpression()
+            '$replaceRoot' => $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression()
         ];
+    }
+
+    /**
+     * Converts an expression object into an array, recursing into nested items
+     *
+     * This method is meant to be overwritten by extending classes to apply
+     * custom conversions (e.g. field name translation in MongoDB ODM) to the
+     * expression object.
+     *
+     * @param mixed|self $expression
+     * @return string|array
+     */
+    protected function convertExpression($expression)
+    {
+        return Expr::convertExpression($expression);
     }
 }


### PR DESCRIPTION
This was introduced in #292 by adding a `convertExpression` method and using that in the expression operator methods. Unfortunately, MongoDB ODM relied on the `ensureArray` method being called to do the type conversion, which is no longer the case since all methods call `convertExpression`.