### PR TITLE
Test against PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,43 +2,64 @@ dist: trusty
 sudo: false
 language: php
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+services:
+  - mongodb
 
 env:
   global:
-    - KEY_SERVER="hkp://keyserver.ubuntu.com:80"
-    - MONGO_REPO_URI="http://repo.mongodb.com/apt/ubuntu"
-    - MONGO_REPO_TYPE="precise/mongodb-enterprise/"
-    - SOURCES_LOC="/etc/apt/sources.list.d/mongodb.list"
     - DRIVER_VERSION="stable"
     - ADAPTER_VERSION="^1.0.0"
-    - SERVER_VERSION="3.2"
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" SERVER_VERSION="2.6" PREFER_LOWEST="--prefer-lowest"
-
-before_install:
-  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv 7F0CEB10
-  - sudo apt-key adv --keyserver ${KEY_SERVER} --recv EA312927
-  - echo "deb ${MONGO_REPO_URI} ${MONGO_REPO_TYPE}${SERVER_VERSION} multiverse" | sudo tee ${SOURCES_LOC}
-  - sudo apt-get update -qq
-
-install:
-  - sudo apt-get install mongodb-enterprise
-  - sleep 1
-  - if ! nc -z localhost 27017; then sudo service mongod start; fi
+      env: DRIVER_VERSION="1.5.8" COMPOSER_FLAGS="--prefer-lowest"
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.0 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.0.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 5.6
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 7.0
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 7.1
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
+    - php: 7.2
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb [arch=amd64] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 multiverse"
+              key_url: "https://www.mongodb.org/static/pgp/server-3.4.asc"
+            - "mongodb-upstart"
+          packages: ['mongodb-org-server']
 
 before_script:
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then yes '' | pecl -q install -f mongo-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then pecl install -f mongodb-${DRIVER_VERSION}; fi
   - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
-  - composer update ${PREFER_LOWEST}
+  - composer update ${COMPOSER_FLAGS}
 
 script:
     - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.6
-      env: DRIVER_VERSION="1.5.8" COMPOSER_FLAGS="--prefer-lowest"
+      env: DRIVER_VERSION="1.6.7" COMPOSER_FLAGS="--prefer-lowest"
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
-sudo: required
+dist: trusty
+sudo: false
 language: php
 
 php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   global:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "ext-mongo": "^1.5",
+        "ext-mongo": "^1.6.7",
         "doctrine/common": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
So, turns out that `mongodb-enterprise` [could no longer be installed](https://travis-ci.org/doctrine/mongodb/jobs/261040827#L509), which is why we're now testing against `mongodb-org-server`. Unfortunately, the oldest available version is 3.0, so we're now testing against that as lowest version. To make matters more interesting, the 1.5 driver [causes interesting test failures](https://travis-ci.org/doctrine/mongodb/jobs/261488830#L562), so we're requiring `ext-mongo` 1.6 now. The lowest version to not [throw a segmentation fault](https://travis-ci.org/doctrine/mongodb/jobs/261536274#L552) is 1.6.7, so that will be our new `ext-mongo` requirement.