### PR TITLE
Fix wrong name for $bucketAuto pipeline stage

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/AbstractBucket.php
@@ -44,13 +44,13 @@ abstract class AbstractBucket extends Stage
     public function getExpression()
     {
         $stage = [
-            '$bucket' => [
+            $this->getStageName() => [
                 'groupBy' => $this->convertExpression($this->groupBy),
             ] + $this->getExtraPipelineFields(),
         ];
 
         if ($this->output !== null) {
-            $stage['$bucket']['output'] = $this->output->getExpression();
+            $stage[$this->getStageName()]['output'] = $this->output->getExpression();
         }
 
         return $stage;
@@ -75,4 +75,11 @@ abstract class AbstractBucket extends Stage
      * @return array
      */
     abstract protected function getExtraPipelineFields();
+
+    /**
+     * Returns the stage name with the dollar prefix
+     *
+     * @return string
+     */
+    abstract protected function getStageName();
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
@@ -102,4 +102,9 @@ class Bucket extends AbstractBucket
 
         return $fields;
     }
+
+    protected function getStageName()
+    {
+        return '$bucket';
+    }
 }

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/BucketAuto.php
@@ -97,4 +97,9 @@ class BucketAuto extends AbstractBucket
 
         return $fields;
     }
+
+    protected function getStageName()
+    {
+        return '$bucketAuto';
+    }
 }

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/BucketAutoTest.php
@@ -21,7 +21,7 @@ class BucketAutoTest extends TestCase
                 ->field('averageValue')
                 ->avg('$value');
 
-        $this->assertSame(['$bucket' => [
+        $this->assertSame(['$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
             'granularity' => 'R10',
@@ -40,7 +40,7 @@ class BucketAutoTest extends TestCase
                 ->field('averageValue')
                 ->avg('$value');
 
-        $this->assertSame([['$bucket' => [
+        $this->assertSame([['$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
             'granularity' => 'R10',
@@ -55,7 +55,7 @@ class BucketAutoTest extends TestCase
             ->groupBy('$someField')
             ->buckets(3);
 
-        $this->assertSame(['$bucket' => [
+        $this->assertSame(['$bucketAuto' => [
             'groupBy' => '$someField',
             'buckets' => 3,
         ]], $bucketStage->getExpression());


### PR DESCRIPTION
This fixes a rather silly copy/paste mistake on my part. I'll note that this fix technically constitutes a BC break, as we're adding a new abstract method to a class. Given the lack of bug reports and the fact that ODM 1.2 with support for the aggregation framework still hasn't hit yet, i'm willing to push the fix this way. Other option would be to have `getStageName` non-abstract and return `$bucket` in `AbstractBucket` and only override the method in `BucketAuto`.