### PR TITLE
Allow passing bucket boundaries as an array as well

### DIFF
--- a/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/Bucket.php
@@ -55,6 +55,10 @@ class Bucket extends AbstractBucket
      */
     public function boundaries(...$boundaries)
     {
+        if (count($boundaries) === 1 && is_array($boundaries[0])) {
+            $boundaries = $boundaries[0];
+        }
+
         $this->boundaries = $boundaries;
         return $this;
     }


### PR DESCRIPTION
Sometimes we have use cases when boundaries are created dynamically or read from config files.