### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Doctrine/MongoDB/Tests/CursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/CursorTest.php
@@ -95,7 +95,7 @@ class CursorTest extends DatabaseTestCase
             /* Note: Driver versions before 1.5.0 had an off-by-one error and
              * count from one, so just assert the key's type here.
              */
-            $this->assertTrue(is_integer($key));
+            $this->assertInternalType('int', $key);
         }
     }
 

--- a/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
+++ b/tests/Doctrine/MongoDB/Tests/EagerCursorTest.php
@@ -47,7 +47,7 @@ class EagerCursorTest extends DatabaseTestCase
         $eagerCursor = new EagerCursor($cursor);
 
         $this->assertFalse($eagerCursor->isInitialized());
-        $this->assertEquals(2, count($eagerCursor));
+        $this->assertCount(2, $eagerCursor);
         $this->assertTrue($eagerCursor->isInitialized());
     }
 

--- a/tests/Doctrine/MongoDB/Tests/GridFSTest.php
+++ b/tests/Doctrine/MongoDB/Tests/GridFSTest.php
@@ -72,13 +72,13 @@ class GridFSTest extends DatabaseTestCase
         $gridFS->update(['_id' => $id], ['$pushAll' => ['test' => [1, 2, 3]]]);
         $check = $gridFS->findOne(['_id' => $id]);
         $this->assertTrue(isset($check['test']));
-        $this->assertEquals(3, count($check['test']));
+        $this->assertCount(3, $check['test']);
         $this->assertEquals([1, 2, 3], $check['test']);
 
         $gridFS->update(['_id' => $id], ['_id' => $id]);
         $gridFS->update(['_id' => $id], ['_id' => $id, 'boom' => true]);
         $check = $gridFS->findOne(['_id' => $id]);
-        $this->assertFalse(array_key_exists('test', $check));
+        $this->assertArrayNotHasKey('test', $check);
         $this->assertTrue($check['boom']);
     }
 
@@ -112,7 +112,7 @@ class GridFSTest extends DatabaseTestCase
         $document = $gridFS->findOne(['_id' => 123]);
 
         $this->assertNotNull($document);
-        $this->assertFalse(array_key_exists('x', $document));
+        $this->assertArrayNotHasKey('x', $document);
     }
 
     public function testUpsertModifierWithoutFile()

--- a/tests/Doctrine/MongoDB/Tests/RetryTest.php
+++ b/tests/Doctrine/MongoDB/Tests/RetryTest.php
@@ -27,7 +27,7 @@ class RetryTest extends DatabaseTestCase
         $check = $test->find(['test' => 'test']);
         $this->assertInstanceOf('Doctrine\MongoDB\Cursor', $check);
         $array = $check->toArray();
-        $this->assertTrue(is_array($array));
+        $this->assertInternalType('array', $array);
         $array = array_values($array);
         $this->assertEquals('test', $array[0]['test']);
     }


### PR DESCRIPTION
Continuing to refactory tests, like #309, I used:
- `assertInternalType` instead of `is_*` functions;
- `assertCount` instead of `count` function;
- `assertArrayNotHasKey` instead of `array_key_exists` function.