### PR TITLE
Use primary read preference when reading newly peristed GridFS files

### DIFF
--- a/lib/Doctrine/MongoDB/Query/Query.php
+++ b/lib/Doctrine/MongoDB/Query/Query.php
@@ -481,17 +481,10 @@ class Query implements IteratorAggregate
         $object->setReadPreference($this->query['readPreference'], $this->query['readPreferenceTags']);
 
         try {
-            $result = $closure();
-        } catch (\Exception $e) {
+            return $closure();
+        } finally {
+            $prevTags = ! empty($prevReadPref['tagsets']) ? $prevReadPref['tagsets'] : [];
+            $object->setReadPreference($prevReadPref['type'], $prevTags);
         }
-
-        $prevTags = ! empty($prevReadPref['tagsets']) ? $prevReadPref['tagsets'] : null;
-        $object->setReadPreference($prevReadPref['type'], $prevTags);
-
-        if (isset($e)) {
-            throw $e;
-        }
-
-        return $result;
     }
 }


### PR DESCRIPTION
This bug can appear when working on a replica set and assigning GridFS documents a secondary read preference (e.g. via the `@ReadPreference` mapping in Doctrine MongoDB ODM). The library stores the file, then reads it from the database to fetch current metadata. If the document is using a secondary read preference, this can lead to the document not being found. Furthermore, due to insufficient error handling, this will not be a regular exception but a type error when assigning the result to the `GridFSFile` instance.

Last but not least, the file was read twice from the database with the result of the first read not being used, so this should also (slightly) improve performance of GridFS write operations.