### PR TITLE
Fix wrong syntax for replaceRoot stage

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -4,6 +4,11 @@ CHANGELOG for 1.6.x
 This changelog references the relevant changes (bug and security fixes) done
 in 1.6.x patch versions.
 
+1.6.4 (2019-07-10)
+------------------
+
+ * [#333](https://github.com/doctrine/mongodb/pull/333): Fix wrong syntax for replaceRoot stage
+
 1.6.3 (2018-07-20)
 ------------------
 

--- a/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
+++ b/lib/Doctrine/MongoDB/Aggregation/Stage/ReplaceRoot.php
@@ -4,6 +4,7 @@ namespace Doctrine\MongoDB\Aggregation\Stage;
 
 use Doctrine\MongoDB\Aggregation\Builder;
 use Doctrine\MongoDB\Aggregation\Expr;
+use function is_array;
 
 /**
  * Fluent interface for adding a $replaceRoot stage to an aggregation pipeline.
@@ -35,8 +36,12 @@ class ReplaceRoot extends Operator
      */
     public function getExpression()
     {
+        $expression = $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression();
+
         return [
-            '$replaceRoot' => $this->expression !== null ? $this->convertExpression($this->expression) : $this->expr->getExpression()
+            '$replaceRoot' => [
+                'newRoot' => is_array($expression) ? (object) $expression : $expression,
+            ],
         ];
     }
 

--- a/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
+++ b/tests/Doctrine/MongoDB/Tests/Aggregation/Stage/ReplaceRootTest.php
@@ -17,7 +17,16 @@ class ReplaceRootTest extends TestCase
             ->field('product')
             ->multiply('$field', 5);
 
-        $this->assertSame(['$replaceRoot' => ['product' => ['$multiply' => ['$field', 5]]]], $replaceRootStage->getExpression());
+        $this->assertEquals(
+            [
+                '$replaceRoot' => [
+                    'newRoot' => (object) [
+                        'product' => ['$multiply' => ['$field', 5]],
+                    ],
+                ],
+            ],
+            $replaceRootStage->getExpression()
+        );
     }
 
     public function testReplaceRootFromBuilder()
@@ -28,7 +37,18 @@ class ReplaceRootTest extends TestCase
                 ->field('product')
                 ->multiply('$field', 5);
 
-        $this->assertSame([['$replaceRoot' => ['product' => ['$multiply' => ['$field', 5]]]]], $builder->getPipeline());
+        $this->assertEquals(
+            [
+                [
+                    '$replaceRoot' => [
+                        'newRoot' => (object) [
+                            'product' => ['$multiply' => ['$field', 5]],
+                        ],
+                    ],
+                ],
+            ],
+            $builder->getPipeline()
+        );
     }
 
     public function testReplaceWithEmbeddedDocument()
@@ -36,6 +56,15 @@ class ReplaceRootTest extends TestCase
         $builder = $this->getTestAggregationBuilder();
         $builder->replaceRoot('$some.embedded.document');
 
-        $this->assertSame([['$replaceRoot' => '$some.embedded.document']], $builder->getPipeline());
+        $this->assertEquals(
+            [
+                [
+                    '$replaceRoot' => [
+                        'newRoot' => '$some.embedded.document'
+                    ]
+                ]
+            ],
+            $builder->getPipeline()
+        );
     }
 }


### PR DESCRIPTION
This PR fixes a wrong syntax for replaceRoot, as reported in https://github.com/doctrine/DoctrineMongoDBBundle/issues/565.