### PR TITLE
Update version information for documentation

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,15 +6,15 @@
     "docsSlug": "doctrine-mongodb",
     "versions": [
         {
-            "name": "master",
-            "branchName": "master",
-            "slug": "latest"
-        },
-        {
             "name": "1.6",
             "branchName": "1.6.x",
             "slug": "1.6",
-            "current": true
+            "current": true,
+            "maintained": false,
+            "aliases": [
+                "latest",
+                "stable"
+            ]
         }
     ]
 }


### PR DESCRIPTION
With ODM 2.0 released, we're no longer actively developing the MongoDB abstraction layer. We're also no longer actively supporting 1.x, except for critical fixes that impact ODM. Thus, the documentation should convey that people shouldn't use this project anymore.

This project will be archived once the maintenance period for ODM 1.x runs out (which will be around April 2020).